### PR TITLE
Added support for miltizone configuration

### DIFF
--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -205,7 +205,7 @@ async def async_setup(hass, config):
 
         if "multizone_probabilities" in call.data:
             tmpdata["mzv"] = []
-            for idx, val in enumerate(call.data["multizone_probabilities"]]):
+            for idx, val in enumerate(call.data["multizone_probabilities"]):
                 for _ in range(val):
                     tmpdata["mzv"].append(idx)
             data = json.dumps(tmpdata)

--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -177,7 +177,7 @@ async def async_setup(hass, config):
 
         if "id" in call.data:
             _LOGGER.debug("Data from Home Assistant: %s", call.data["id"])
-    
+
             for cli in client:
                 attrs = vars(cli)
                 if (attrs["id"] == int(call.data["id"])):
@@ -191,17 +191,32 @@ async def async_setup(hass, config):
             sendData = True
 
         if "timeextension" in call.data:
-            tmpdata["sc"] = {} 
+            tmpdata["sc"] = {}
             tmpdata["sc"]["p"] = int(call.data["timeextension"])
             data = json.dumps(tmpdata)
             _LOGGER.debug("Setting time_extension for %s to %s", client[id].name, call.data["timeextension"])
+            sendData = True
+
+        if "multizone_distances" in call.data:
+            tmpdata["mz"] = [int(x) for x in call.data["multizone_distances"]]
+            data = json.dumps(tmpdata)
+            _LOGGER.debug("Setting multizone distances for %s to %s", client[id].name, call.data["multizone_distances"])
+            sendData = True
+
+        if "multizone_probabilities" in call.data:
+            tmpdata["mzv"] = []
+            for idx, val in enumerate(call.data["multizone_probabilities"]]):
+                for _ in range(val):
+                    tmpdata["mzv"].append(idx)
+            data = json.dumps(tmpdata)
+            _LOGGER.debug("Setting multizone probabilities for %s to %s", client[id].name, call.data["multizone_probabilities"])
             sendData = True
 
         if sendData:
             data = json.dumps(tmpdata)
             _LOGGER.debug("Sending: %s", data)
             client[id].sendData(data)
-            
+
     hass.services.async_register(DOMAIN, SERVICE_CONFIG, handle_config)
 
     return True

--- a/custom_components/landroid_cloud/services.yaml
+++ b/custom_components/landroid_cloud/services.yaml
@@ -28,3 +28,9 @@ config:
     timeextension:
       description: Set time extension. Extension in % ranging from -100 to 100
       example: -23
+    multizone_distances:
+      description: Set multizone distances. Distances in meter. 0 = Disabled
+      example: [15, 80, 120, 155]
+    multizone_probabilities:
+      description: Set multizone probabilities. Probabilities in parts-of-ten. 1 = 10%, 2 = 20%, ...
+      example: [5, 1, 2, 2]


### PR DESCRIPTION
Regarding the issue #36 I added multizone support to the component. In detail, the following features were added

- Support for setting the multizone probabilities (in parts of then, i.e. [2, 3, 5, 0] means 20% for selecting zone 1, 30% for zone 2 etc)
- Support for setting the distance in meters which are traveled by the mover to reach a given zone.

The conventions used for setting rain delay and time extensions have been followed. A useful extension would be to read out the current values (i.e. probability and distance) and add them to the status sensor.