### PR TITLE
Add poll command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ sensor.landroid_[NAME_FROM_APP]_status
 In addition, the following services are created:
 
 ```
+landroid_cloud.poll
 landroid_cloud.start
 landroid_cloud.home
 landroid_cloud.pause

--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -40,6 +40,7 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+SERVICE_POLL = "poll"
 SERVICE_START = "start"
 SERVICE_PAUSE = "pause"
 SERVICE_HOME = "home"
@@ -126,6 +127,20 @@ async def async_setup(hass, config):
             async_track_time_interval(hass, api.async_force_update, FORCED_UPDATE)
             hass.data[LANDROID_API][dev] = api
             dev += 1
+
+    async def handle_poll(call):
+        """Handle poll service call."""
+        if "id" in call.data:
+            ID = int(call.data["id"])
+
+            for cli in client:
+                attrs = vars(cli)
+                if attrs["id"] == ID:
+                    cli.poll()
+        else:
+            client[0].poll()
+
+    hass.services.async_register(DOMAIN, SERVICE_POLL, handle_poll)
 
     async def handle_start(call):
         """Handle start service call."""

--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -136,9 +136,14 @@ async def async_setup(hass, config):
             for cli in client:
                 attrs = vars(cli)
                 if attrs["id"] == ID:
-                    cli.poll()
+                    error = cli.tryToPoll()
+                    if error is not None:
+                        _LOGGER.warning(error)
+
         else:
-            client[0].poll()
+            error = client[0].tryToPoll()
+            if error is not None:
+                _LOGGER.warning(error)
 
     hass.services.async_register(DOMAIN, SERVICE_POLL, handle_poll)
 

--- a/custom_components/landroid_cloud/services.yaml
+++ b/custom_components/landroid_cloud/services.yaml
@@ -1,3 +1,9 @@
+poll:
+  description: Poll mower status info
+  fields:
+    id:
+      description: Landroid ID. Found as attribute on the Landroid status sensor
+      example: 123435
 start:
   description: Start mowing
   fields:


### PR DESCRIPTION
This PR, together with https://github.com/MTrab/pyworxcloud/pull/3, adds the ability to force poll status information of a lawn mower. This can be useful for example to get status information between regular status updates.