### PR TITLE
Add support for 'landxcape' and 'kress'

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ landroid_cloud:
     password: AnotherPassword
 ```
 
+If you have LandXcape or Kress robots you can add `type` to the config instead of default 'worx':
+
+```
+landroid_cloud:
+  - email: this@example.com
+    password: YourPassword
+    type: landxcape
+```
+
 ### Entities & Services
 
 Once installed, the following entities are created in Home Assistant:

--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -6,7 +6,7 @@ import time
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TYPE
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
@@ -33,7 +33,7 @@ CONFIG_SCHEMA = vol.Schema(
                     {
                         vol.Required(CONF_EMAIL): cv.string,
                         vol.Required(CONF_PASSWORD): cv.string,
-                        vol.Optional(CONF_TYPE): cv.string,
+                        vol.Optional('type'): cv.string,
                     }
                 )
             ],
@@ -111,7 +111,7 @@ async def async_setup(hass, config):
     for cloud in config[DOMAIN]:
         cloud_email = cloud[CONF_EMAIL]
         cloud_password = cloud[CONF_PASSWORD]
-        cloud_type = cloud[CONF_TYPE] if cloud[CONF_TYPE] else 'worx'
+        cloud_type = cloud['type'] if cloud['type'] else 'worx'
 
         master = pyworxcloud.WorxCloud()
         auth = await master.initialize(cloud_email, cloud_password, cloud_type)

--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -6,7 +6,7 @@ import time
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TYPE
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
@@ -33,6 +33,7 @@ CONFIG_SCHEMA = vol.Schema(
                     {
                         vol.Required(CONF_EMAIL): cv.string,
                         vol.Required(CONF_PASSWORD): cv.string,
+                        vol.Optional(CONF_TYPE): cv.string,
                     }
                 )
             ],
@@ -110,9 +111,10 @@ async def async_setup(hass, config):
     for cloud in config[DOMAIN]:
         cloud_email = cloud[CONF_EMAIL]
         cloud_password = cloud[CONF_PASSWORD]
+        cloud_type = cloud[CONF_TYPE] if cloud[CONF_TYPE] else 'worx'
 
         master = pyworxcloud.WorxCloud()
-        auth = await master.initialize(cloud_email, cloud_password)
+        auth = await master.initialize(cloud_email, cloud_password, cloud_type)
 
         if not auth:
             _LOGGER.warning("Error in authentication!")
@@ -124,7 +126,7 @@ async def async_setup(hass, config):
             client.append(dev)
             _LOGGER.debug("Connecting to device ID %s (%s)", device, cloud_email)
             client[dev] = pyworxcloud.WorxCloud()
-            await client[dev].initialize(cloud_email, cloud_password)
+            await client[dev].initialize(cloud_email, cloud_password, cloud_type)
             await hass.async_add_executor_job(client[dev].connect, device, False)
 
             api = WorxLandroidAPI(hass, dev, client[dev], config)

--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -111,8 +111,7 @@ async def async_setup(hass, config):
     for cloud in config[DOMAIN]:
         cloud_email = cloud[CONF_EMAIL]
         cloud_password = cloud[CONF_PASSWORD]
-        if cloud[CONF_TYPE] = None:
-            cloud_type = 'worx'
+        cloud_type = cloud.get(CONF_TYPE, 'worx')
 
         master = pyworxcloud.WorxCloud()
         auth = await master.initialize(cloud_email, cloud_password, cloud_type)

--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -6,7 +6,7 @@ import time
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TYPE
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
@@ -33,7 +33,7 @@ CONFIG_SCHEMA = vol.Schema(
                     {
                         vol.Required(CONF_EMAIL): cv.string,
                         vol.Required(CONF_PASSWORD): cv.string,
-                        vol.Optional('type'): cv.string,
+                        vol.Optional(CONF_TYPE): cv.string,
                     }
                 )
             ],
@@ -111,7 +111,8 @@ async def async_setup(hass, config):
     for cloud in config[DOMAIN]:
         cloud_email = cloud[CONF_EMAIL]
         cloud_password = cloud[CONF_PASSWORD]
-        cloud_type = cloud['type'] if cloud['type'] else 'worx'
+        if cloud[CONF_TYPE] = None:
+            cloud_type = 'worx'
 
         master = pyworxcloud.WorxCloud()
         auth = await master.initialize(cloud_email, cloud_password, cloud_type)


### PR DESCRIPTION
The default type of robot is `worx`. To select other types of supported robots use `type` config option. I.e.:
```
landroid_cloud:
  - email: user@example.com
    password: password
    type: landxcape
```
Tested with my LandXcape LX790i