### PR TITLE
Fix issue of 'WorxCloud' object without 'partymode' or 'ots_enabled' attribute

### DIFF
--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -151,10 +151,15 @@ async def async_setup(hass, config):
             async_track_time_interval(hass, api.async_update, SCAN_INTERVAL)
             async_track_time_interval(hass, api.async_force_update, FORCED_UPDATE)
             hass.data[LANDROID_API][dev] = api
-            _LOGGER.debug("Partymode available: %s", client[dev].partymode)
-            if not partymode and client[dev].partymode:
+            if not hasattr(client[dev], 'partymode'):
+                partymode = False
+            elif not partymode and client[dev].partymode:
+                _LOGGER.debug("Partymode available: %s", client[dev].partymode)
                 partymode = True
-            if not ots and client[dev].ots_enabled:
+            if not hasattr(client[dev], 'ots_enabled'):
+                ots = False
+            elif not ots and client[dev].ots_enabled:
+                _LOGGER.debug("OTS enabled: %s", client[dev].ots_enabled)
                 ots = True
             dev += 1
     


### PR DESCRIPTION
When WorxCloud object has no attributes of 'partymode' OR 'ots_enabled', the integration fails to load with the following error messages:

2021-12-31 11:18:21 ERROR (MainThread) [homeassistant.setup] Error during setup of component landroid_cloud
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/setup.py", line 229, in _async_setup_component
result = await task
File "/config/custom_components/landroid_cloud/__init__.py", line 154, in async_setup
_LOGGER.debug("Partymode available: %s", client[dev].partymode)
AttributeError: 'WorxCloud' object has no attribute 'partymode'
2021-12-31 11:18:21 ERROR (MainThread) [homeassistant.setup] Unable to prepare setup for platform landroid_cloud.sensor: Unable to set up component.


2021-12-31 11:34:02 ERROR (MainThread) [homeassistant.setup] Error during setup of component landroid_cloud
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/setup.py", line 229, in _async_setup_component
result = await task
File "/config/custom_components/landroid_cloud/__init__.py", line 160, in async_setup
if not ots and client[dev].ots_enabled:
AttributeError: 'WorxCloud' object has no attribute 'ots_enabled'
2021-12-31 11:34:02 ERROR (MainThread) [homeassistant.setup] Unable to prepare setup for platform landroid_cloud.sensor: Unable to set up component.

Simply check previously to requesting the state of the attributes, if these exist.