### PR TITLE
Feature/single attributes

### DIFF
--- a/custom_components/landroid_cloud/device_base.py
+++ b/custom_components/landroid_cloud/device_base.py
@@ -8,7 +8,7 @@ import pprint
 import time
 from datetime import timedelta
 from functools import partial
-from typing import Any
+from typing import Any, Mapping
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
@@ -619,7 +619,7 @@ class LandroidCloudMowerBase(LandroidCloudBaseEntity, StateVacuumEntity):
         )
 
     @property
-    def extra_state_attributes(self) -> str:
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return sensor attributes."""
         return self._attributes
 

--- a/custom_components/landroid_cloud/device_base.py
+++ b/custom_components/landroid_cloud/device_base.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import asyncio
 import json
 import pprint
+import sys
 import time
 from datetime import timedelta
 from functools import partial
-from typing import Any, Mapping
+from typing import Any, Mapping, Generator
+
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:
+    from collections.abc import MutableMapping
+else:
+    from collections import MutableMapping
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.components.select import SelectEntity, SelectEntityDescription


### PR DESCRIPTION
Convert `extra_state_attributes` reported to HA to a flattened dictionary of scalar values (single state attributes)

closes #268

Note: Introduces braking changes if not keeping previous version of attribute representation which means doubling attributes