### PR TITLE
Fix timeout handling

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -15,7 +15,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud==3.1.3"
+        "pyworxcloud==3.1.4"
     ],
     "version": "3.0.0b4"
 }


### PR DESCRIPTION
Fixes #341 (hopefully)

Also as a bonus the new pyworxcloud module fetches model info from the API, so the model and model code is now displayed correct in the device overview