### PR TITLE
Switch to new global SSO domains

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -15,7 +15,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud==3.1.8"
+        "pyworxcloud==3.1.9"
     ],
     "version": "3.0.1"
 }


### PR DESCRIPTION
As per API documentation Worx and Kress SSO domains have been switched from EU to Global