### PR TITLE
Fix NoneType value for blade.reset_at property

### DIFF
--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -115,7 +115,7 @@ SENSORS = [
         suggested_display_precision=0,
         value_fn=lambda landroid: (
             round(landroid.blades["reset_at"] / 60, 2)
-            if "reset_at" in landroid.blades
+            if "reset_at" in landroid.blades and not landroid.blades["reset_at"] is None
             else None
         ),
         icon="mdi:history",


### PR DESCRIPTION
Fix issue where "reset_at" blade property exists but is of none type (this e.g. happens with model "Landroid S500 (WR105SI.1)").

```
ERROR (MainThread) [homeassistant.util.logging] Exception in handle_update when dispatching 'landroid_cloud_update_alt': ()
Traceback (most recent call last):
File "/config/custom_components/landroid_cloud/device_base.py", line 1035, in handle_update
new_val = self.entity_description.value_fn(self.device)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/landroid_cloud/sensor.py", line 117, in <lambda>
round(landroid.blades["reset_at"] / 60, 2)
~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```
