### PR TITLE
Bump Home Assistant requirements to at least 2024.10

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Landroid Cloud",
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"image": "mcr.microsoft.com/devcontainers/python:3.12-bullseye",
 	"postCreateCommand": "scripts/setup",
 	"appPort": [
 		"9123:8123"
@@ -37,9 +37,6 @@
 	},
 	"remoteUser": "root",
 	"features": {
-		"ghcr.io/devcontainers/features/rust:1": {},
-		"ghcr.io/devcontainers/features/python:1": {
-			"version": "latest"
-		}
+		"ghcr.io/devcontainers/features/rust:1": {}
 	}
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Landroid Cloud",
   "render_readme": false,
-  "homeassistant": "2023.10.0",
+  "homeassistant": "2024.10.0",
   "zip_release": true,
   "filename": "landroid_cloud.zip"
 }


### PR DESCRIPTION
In some way a fixes #712 as the changes requires Home Assistant to be at least 2024.10.0