### PR TITLE
Add default name when mower is unnamed Fixes #897

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -15,7 +15,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud==4.1.38"
+        "pyworxcloud==4.1.39"
     ],
     "version": "5.2.8"
 }

--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -15,7 +15,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud==4.1.39"
+        "pyworxcloud==4.1.40"
     ],
     "version": "5.2.8"
 }


### PR DESCRIPTION
Fixes #897

Unnamed devices will by default be named `No Name`