### PR TITLE
Fix formatter failure on sensor branch

### DIFF
--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -21,7 +21,13 @@ from pyworxcloud.exceptions import (
     TooManyRequestsError,
 )
 
-from .const import CONF_CLOUD, CONF_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT, DOMAIN, PLATFORMS
+from .const import (
+    CONF_CLOUD,
+    CONF_COMMAND_TIMEOUT,
+    DEFAULT_COMMAND_TIMEOUT,
+    DOMAIN,
+    PLATFORMS,
+)
 from .coordinator import LandroidCloudCoordinator
 from .models import LandroidRuntimeData
 
@@ -35,7 +41,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: LandroidConfigEntry) -> 
         entry.data[CONF_PASSWORD],
         entry.data[CONF_CLOUD],
         tz=hass.config.time_zone,
-        command_timeout=entry.options.get(CONF_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT),
+        command_timeout=entry.options.get(
+            CONF_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT
+        ),
     )
 
     try:
@@ -47,7 +55,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: LandroidConfigEntry) -> 
         raise ConfigEntryNotReady("Cloud endpoint rejected setup request") from err
     except TooManyRequestsError as err:
         raise ConfigEntryNotReady("Too many requests to cloud API") from err
-    except (NoConnectionError, ServiceUnavailableError, InternalServerError, TimeoutError) as err:
+    except (
+        NoConnectionError,
+        ServiceUnavailableError,
+        InternalServerError,
+        TimeoutError,
+    ) as err:
         raise ConfigEntryNotReady("Cloud service unavailable") from err
     except APIException as err:
         raise ConfigEntryNotReady("Unexpected API error") from err

--- a/custom_components/landroid_cloud/const.py
+++ b/custom_components/landroid_cloud/const.py
@@ -26,6 +26,7 @@ DEFAULT_COMMAND_TIMEOUT = 30.0
 MIN_COMMAND_TIMEOUT = 1.0
 MAX_COMMAND_TIMEOUT = 120.0
 
+
 class CloudProvider(StrEnum):
     """Supported cloud providers."""
 


### PR DESCRIPTION
## Summary
- run the same formatting tools as CI (

                 _                 _
                (_) ___  ___  _ __| |_
                | |/ _/ / _ \/ '__  _/
                | |\__ \/\_\/| |  | |_
                |_|\___/\___/\_/   \_/

      isort your imports, so you don't have to.

                    VERSION 8.0.1


Nothing to do: no files or paths have been passed in!

Try one of the following:

    `isort .` - sort all Python files, starting from the current directory, recursively.
    `isort . --interactive` - Do the same, but ask before making any changes.
    `isort . --check --diff` - Check to see if imports are correctly sorted within this project.
    `isort --help` - In-depth information about isort's available command-line options.

Visit https://pycqa.github.io/isort/ for complete information about how to use isort. + )
- commit resulting formatting changes in  and 

## Test strategy
- local run of workflow-equivalent formatting commands:
  - 
                 _                 _
                (_) ___  ___  _ __| |_
                | |/ _/ / _ \/ '__  _/
                | |\__ \/\_\/| |  | |_
                |_|\___/\___/\_/   \_/

      isort your imports, so you don't have to.

                    VERSION 8.0.1

else-type place_module for json returned STDLIB
else-type place_module for os returned STDLIB
else-type place_module for sys returned STDLIB
from-type place_module for __future__ returned FUTURE
from-type place_module for dataclasses returned STDLIB
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for .coordinator returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for asyncio returned STDLIB
else-type place_module for logging returned STDLIB
from-type place_module for typing returned STDLIB
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for homeassistant.helpers.update_coordinator returned THIRDPARTY
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for .const returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for asyncio returned STDLIB
from-type place_module for typing returned STDLIB
else-type place_module for voluptuous returned THIRDPARTY
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for pyworxcloud.exceptions returned THIRDPARTY
from-type place_module for .const returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for collections.abc returned STDLIB
from-type place_module for dataclasses returned STDLIB
from-type place_module for typing returned STDLIB
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.helpers.device_registry returned THIRDPARTY
from-type place_module for homeassistant.helpers.entity returned THIRDPARTY
from-type place_module for homeassistant.helpers.update_coordinator returned THIRDPARTY
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .coordinator returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for collections.abc returned STDLIB
from-type place_module for homeassistant.exceptions returned THIRDPARTY
from-type place_module for pyworxcloud.exceptions returned THIRDPARTY
from-type place_module for __future__ returned FUTURE
from-type place_module for dataclasses returned STDLIB
from-type place_module for homeassistant.components.sensor returned THIRDPARTY
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for homeassistant.helpers.entity_platform returned THIRDPARTY
from-type place_module for .entity returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for asyncio returned STDLIB
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for homeassistant.exceptions returned THIRDPARTY
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for pyworxcloud.exceptions returned THIRDPARTY
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .coordinator returned LOCALFOLDER
from-type place_module for .models returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for enum returned STDLIB
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for __future__ returned FUTURE
from-type place_module for typing returned STDLIB
from-type place_module for homeassistant.components.diagnostics returned THIRDPARTY
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for .const returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for voluptuous returned THIRDPARTY
from-type place_module for homeassistant.components.device_automation returned THIRDPARTY
from-type place_module for homeassistant.components.lawn_mower.const returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for homeassistant.helpers returned THIRDPARTY
from-type place_module for homeassistant.helpers returned THIRDPARTY
from-type place_module for homeassistant.helpers.typing returned THIRDPARTY
from-type place_module for . returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for homeassistant.components.button returned THIRDPARTY
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for homeassistant.helpers.entity returned THIRDPARTY
from-type place_module for homeassistant.helpers.entity_platform returned THIRDPARTY
from-type place_module for .api returned LOCALFOLDER
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .device_base returned LOCALFOLDER
from-type place_module for .utils.logger returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for homeassistant.helpers.entity_platform returned THIRDPARTY
from-type place_module for .api returned LOCALFOLDER
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .utils.entity_setup returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for homeassistant.components.binary_sensor returned THIRDPARTY
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for .api returned LOCALFOLDER
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .device_base returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for voluptuous returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.helpers returned THIRDPARTY
from-type place_module for .const returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for voluptuous returned THIRDPARTY
from-type place_module for homeassistant.components.device_automation returned THIRDPARTY
from-type place_module for homeassistant.components.homeassistant.triggers returned THIRDPARTY
from-type place_module for homeassistant.components.lawn_mower.const returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for homeassistant.helpers returned THIRDPARTY
from-type place_module for homeassistant.helpers returned THIRDPARTY
from-type place_module for homeassistant.helpers.trigger returned THIRDPARTY
from-type place_module for homeassistant.helpers.typing returned THIRDPARTY
from-type place_module for .const returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for homeassistant.components.switch returned THIRDPARTY
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for .api returned LOCALFOLDER
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .device_base returned LOCALFOLDER
from-type place_module for .utils.logger returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for homeassistant returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for pyworxcloud.exceptions returned THIRDPARTY
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .scheme returned LOCALFOLDER
from-type place_module for .utils.logger returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for .const returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for dataclasses returned STDLIB
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for homeassistant.exceptions returned THIRDPARTY
from-type place_module for homeassistant.helpers returned THIRDPARTY
from-type place_module for homeassistant.helpers returned THIRDPARTY
from-type place_module for homeassistant.helpers.device_registry returned THIRDPARTY
from-type place_module for .api returned LOCALFOLDER
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .scheme returned LOCALFOLDER
from-type place_module for .utils.logger returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for asyncio returned STDLIB
from-type place_module for datetime returned STDLIB
from-type place_module for typing returned STDLIB
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for homeassistant.helpers.dispatcher returned THIRDPARTY
from-type place_module for homeassistant.util returned THIRDPARTY
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for pyworxcloud.events returned THIRDPARTY
from-type place_module for pyworxcloud.utils returned THIRDPARTY
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .utils.logger returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for voluptuous returned THIRDPARTY
from-type place_module for homeassistant.components.lawn_mower.const returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for homeassistant.helpers returned THIRDPARTY
from-type place_module for homeassistant.helpers returned THIRDPARTY
from-type place_module for homeassistant.helpers returned THIRDPARTY
from-type place_module for homeassistant.helpers.config_validation returned THIRDPARTY
from-type place_module for homeassistant.helpers.typing returned THIRDPARTY
from-type place_module for custom_components.landroid_cloud.const returned FIRSTPARTY
from-type place_module for . returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for asyncio returned STDLIB
else-type place_module for contextlib returned STDLIB
else-type place_module for json returned STDLIB
else-type place_module for logging returned STDLIB
else-type place_module for time returned STDLIB
from-type place_module for collections.abc returned STDLIB
from-type place_module for dataclasses returned STDLIB
from-type place_module for datetime returned STDLIB
from-type place_module for functools returned STDLIB
from-type place_module for typing returned STDLIB
from-type place_module for homeassistant.components.binary_sensor returned THIRDPARTY
from-type place_module for homeassistant.components.button returned THIRDPARTY
from-type place_module for homeassistant.components.lawn_mower returned THIRDPARTY
from-type place_module for homeassistant.components.number returned THIRDPARTY
from-type place_module for homeassistant.components.select returned THIRDPARTY
from-type place_module for homeassistant.components.sensor returned THIRDPARTY
from-type place_module for homeassistant.components.switch returned THIRDPARTY
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for homeassistant.exceptions returned THIRDPARTY
from-type place_module for homeassistant.helpers returned THIRDPARTY
from-type place_module for homeassistant.helpers returned THIRDPARTY
from-type place_module for homeassistant.helpers.dispatcher returned THIRDPARTY
from-type place_module for homeassistant.helpers.entity_registry returned THIRDPARTY
from-type place_module for homeassistant.helpers.event returned THIRDPARTY
from-type place_module for homeassistant.util returned THIRDPARTY
from-type place_module for homeassistant.util returned THIRDPARTY
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for pyworxcloud.exceptions returned THIRDPARTY
from-type place_module for pyworxcloud.utils returned THIRDPARTY
from-type place_module for .api returned LOCALFOLDER
from-type place_module for .attribute_map returned LOCALFOLDER
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .utils.logger returned LOCALFOLDER
from-type place_module for .utils.schedules returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for .api returned LOCALFOLDER
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .device_base returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for pytz returned THIRDPARTY
from-type place_module for homeassistant.components.sensor returned THIRDPARTY
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for .api returned LOCALFOLDER
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .device_base returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for asyncio returned STDLIB
else-type place_module for requests returned THIRDPARTY
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for homeassistant.exceptions returned THIRDPARTY
from-type place_module for homeassistant.loader returned THIRDPARTY
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for .api returned LOCALFOLDER
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .services returned LOCALFOLDER
from-type place_module for .utils.logger returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for inspect returned STDLIB
from-type place_module for dataclasses returned STDLIB
from-type place_module for enum returned STDLIB
from-type place_module for homeassistant.components.lawn_mower returned THIRDPARTY
from-type place_module for homeassistant.components.lock returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for pyworxcloud.clouds returned THIRDPARTY
from-type place_module for pyworxcloud.utils returned THIRDPARTY
from-type place_module for .utils.logger returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for json returned STDLIB
from-type place_module for homeassistant.components.number returned THIRDPARTY
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for .api returned LOCALFOLDER
from-type place_module for .const returned LOCALFOLDER
from-type place_module for .device_base returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for typing returned STDLIB
from-type place_module for homeassistant.components.diagnostics returned THIRDPARTY
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for .api returned LOCALFOLDER
from-type place_module for .const returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for ..device_base returned LOCALFOLDER
from-type place_module for ..devices returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for contextlib returned STDLIB
else-type place_module for enum returned STDLIB
else-type place_module for logging returned STDLIB
from-type place_module for ..api returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for re returned STDLIB
from-type place_module for datetime returned STDLIB
from-type place_module for homeassistant.exceptions returned THIRDPARTY
from-type place_module for __future__ returned FUTURE
else-type place_module for logging returned STDLIB
from-type place_module for homeassistant.config_entries returned THIRDPARTY
from-type place_module for homeassistant.const returned THIRDPARTY
from-type place_module for homeassistant.core returned THIRDPARTY
from-type place_module for __future__ returned FUTURE
else-type place_module for voluptuous returned THIRDPARTY
from-type place_module for homeassistant.components.lawn_mower returned THIRDPARTY
from-type place_module for ..const returned LOCALFOLDER
from-type place_module for ..device_base returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
from-type place_module for . returned LOCALFOLDER
from-type place_module for . returned LOCALFOLDER
from-type place_module for . returned LOCALFOLDER
from-type place_module for . returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for voluptuous returned THIRDPARTY
from-type place_module for homeassistant.components.lawn_mower returned THIRDPARTY
from-type place_module for ..const returned LOCALFOLDER
from-type place_module for ..device_base returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for json returned STDLIB
else-type place_module for voluptuous returned THIRDPARTY
from-type place_module for homeassistant.components.lawn_mower returned THIRDPARTY
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for ..const returned LOCALFOLDER
from-type place_module for ..device_base returned LOCALFOLDER
from-type place_module for ..utils.logger returned LOCALFOLDER
from-type place_module for __future__ returned FUTURE
else-type place_module for voluptuous returned THIRDPARTY
from-type place_module for homeassistant.components.lawn_mower returned THIRDPARTY
from-type place_module for pyworxcloud returned THIRDPARTY
from-type place_module for ..const returned LOCALFOLDER
from-type place_module for ..device_base returned LOCALFOLDER
.git was skipped as it's listed in 'skip' setting, matches a glob in 'skip_glob' setting, or is in a .gitignore file with --skip-gitignore enabled.
Skipped 1 files
  - 

## Known limitations
- no functional code changes; formatting-only PR
