### PR TITLE
Fix formatting drift on master

### DIFF
--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -22,7 +22,13 @@ from pyworxcloud.exceptions import (
 )
 
 from .awsiot import async_prime_awsiot_metrics
-from .const import CONF_CLOUD, CONF_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT, DOMAIN, PLATFORMS
+from .const import (
+    CONF_CLOUD,
+    CONF_COMMAND_TIMEOUT,
+    DEFAULT_COMMAND_TIMEOUT,
+    DOMAIN,
+    PLATFORMS,
+)
 from .coordinator import LandroidCloudCoordinator
 from .models import LandroidRuntimeData
 
@@ -36,7 +42,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: LandroidConfigEntry) -> 
         entry.data[CONF_PASSWORD],
         entry.data[CONF_CLOUD],
         tz=hass.config.time_zone,
-        command_timeout=entry.options.get(CONF_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT),
+        command_timeout=entry.options.get(
+            CONF_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT
+        ),
     )
 
     try:
@@ -49,7 +57,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: LandroidConfigEntry) -> 
         raise ConfigEntryNotReady("Cloud endpoint rejected setup request") from err
     except TooManyRequestsError as err:
         raise ConfigEntryNotReady("Too many requests to cloud API") from err
-    except (NoConnectionError, ServiceUnavailableError, InternalServerError, TimeoutError) as err:
+    except (
+        NoConnectionError,
+        ServiceUnavailableError,
+        InternalServerError,
+        TimeoutError,
+    ) as err:
         raise ConfigEntryNotReady("Cloud service unavailable") from err
     except APIException as err:
         raise ConfigEntryNotReady("Unexpected API error") from err

--- a/custom_components/landroid_cloud/const.py
+++ b/custom_components/landroid_cloud/const.py
@@ -18,6 +18,7 @@ DEFAULT_COMMAND_TIMEOUT = 30.0
 MIN_COMMAND_TIMEOUT = 1.0
 MAX_COMMAND_TIMEOUT = 120.0
 
+
 class CloudProvider(StrEnum):
     """Supported cloud providers."""
 

--- a/custom_components/landroid_cloud/lawn_mower.py
+++ b/custom_components/landroid_cloud/lawn_mower.py
@@ -68,7 +68,9 @@ class LandroidCloudMowerEntity(LandroidBaseEntity, LawnMowerEntity):
 
     def __init__(self, coordinator, config_entry, serial_number: str) -> None:
         """Initialize mower entity."""
-        super().__init__(coordinator, config_entry, serial_number, MOWER_DESCRIPTION.key)
+        super().__init__(
+            coordinator, config_entry, serial_number, MOWER_DESCRIPTION.key
+        )
 
     @property
     def name(self) -> str | None:

--- a/tests/test_lawn_mower.py
+++ b/tests/test_lawn_mower.py
@@ -13,4 +13,6 @@ def test_start_sequence_states_map_to_mowing() -> None:
 
 def test_unknown_state_defaults_to_error() -> None:
     """Unknown status ids should not map to non-standard activities."""
-    assert STATUS_ACTIVITY_MAP.get(999, LawnMowerActivity.ERROR) is LawnMowerActivity.ERROR
+    assert (
+        STATUS_ACTIVITY_MAP.get(999, LawnMowerActivity.ERROR) is LawnMowerActivity.ERROR
+    )


### PR DESCRIPTION
## Summary
- apply repository formatting using the same tools as CI
- include only formatting-only changes

## Why
The format workflow reports diffs on master, causing formatter job failures.

## Verification
- python -m isort -v --multi-line 3 --trailing-comma -l 88 --recursive .
- python -m black -v .
