### PR TITLE
Add Lokalise sync workflow for en.json

### DIFF
--- a/.github/workflows/lokalise-push-en.yml
+++ b/.github/workflows/lokalise-push-en.yml
@@ -1,0 +1,52 @@
+name: Push English Translations to Lokalise
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - custom_components/landroid_cloud/translations/en.json
+
+permissions:
+  contents: read
+
+jobs:
+  push-to-lokalise:
+    name: Push en.json to Lokalise
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check Lokalise secrets
+        id: check_secrets
+        env:
+          LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
+          LOKALISE_PROJECT_ID: ${{ secrets.LOKALISE_PROJECT_ID }}
+        run: |
+          if [ -z "$LOKALISE_API_TOKEN" ] || [ -z "$LOKALISE_PROJECT_ID" ]; then
+            echo "has_secrets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_secrets=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push base language file
+        if: steps.check_secrets.outputs.has_secrets == 'true'
+        uses: lokalise/lokalise-push-action@v5.0.0
+        with:
+          api_token: ${{ secrets.LOKALISE_API_TOKEN }}
+          project_id: ${{ secrets.LOKALISE_PROJECT_ID }}
+          base_lang: en
+          translations_path: custom_components/landroid_cloud/translations
+          file_ext: json
+          flat_naming: true
+          name_pattern: en.json
+
+      - name: Explain skipped sync
+        if: steps.check_secrets.outputs.has_secrets == 'false'
+        run: |
+          echo "Skipping Lokalise push because required secrets are missing."
+          echo "Expected secrets: LOKALISE_API_TOKEN and LOKALISE_PROJECT_ID."


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow that triggers when `custom_components/landroid_cloud/translations/en.json` changes on `master`
- push the base English translation file (`en.json`) to Lokalise via `lokalise/lokalise-push-action`
- skip safely with an informational log when Lokalise secrets are missing

## Required repository secrets
- `LOKALISE_API_TOKEN`
- `LOKALISE_PROJECT_ID`

## Notes
- This PR is intentionally clean and only contains the Lokalise workflow file.
