### PR TITLE
Fix Lokalise workflow by disabling tag push

### DIFF
--- a/.github/workflows/lokalise-push-en.yml
+++ b/.github/workflows/lokalise-push-en.yml
@@ -40,6 +40,7 @@ jobs:
           api_token: ${{ secrets.LOKALISE_API_TOKEN }}
           project_id: ${{ secrets.LOKALISE_PROJECT_ID }}
           base_lang: en
+          skip_tagging: true
           translations_path: custom_components/landroid_cloud/translations
           file_ext: json
           flat_naming: true


### PR DESCRIPTION
## Summary
- set `skip_tagging: true` for `lokalise/lokalise-push-action`
- prevents the action from trying to push git tags after upload

## Why
The previous run uploaded `en.json` successfully, then failed on tag push with:
- `Permission to ... denied to github-actions[bot]`
- token only has `contents: read`

## Impact
- Lokalise sync still runs on `en.json` updates
- workflow no longer requires repo write permissions for tagging
