### PR TITLE
Fix Lokalise workflow permissions

### DIFF
--- a/.github/workflows/lokalise-push-en.yml
+++ b/.github/workflows/lokalise-push-en.yml
@@ -9,7 +9,7 @@ on:
       - custom_components/landroid_cloud/translations/en.json
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   push-to-lokalise:


### PR DESCRIPTION
## Summary
- change workflow permissions from `contents: read` to `contents: write`

## Why
The Lokalise push action still performs a first-run tag operation (`lokalise-upload-complete`) and fails with 403 on read-only token permissions, even when `skip_tagging: true` is set.

## Result
- workflow can complete successfully with current action behavior
