### PR TITLE
Add legacy startup banner on integration setup

### DIFF
--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.loader import async_get_integration
 from pyworxcloud import WorxCloud
 from pyworxcloud.exceptions import (
     APIException,
@@ -28,15 +30,20 @@ from .const import (
     DEFAULT_COMMAND_TIMEOUT,
     DOMAIN,
     PLATFORMS,
+    STARTUP,
 )
 from .coordinator import LandroidCloudCoordinator
 from .models import LandroidRuntimeData
 
 type LandroidConfigEntry = ConfigEntry[LandroidRuntimeData]
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: LandroidConfigEntry) -> bool:
     """Set up Landroid Cloud from a config entry."""
+    integration = await async_get_integration(hass, DOMAIN)
+    _LOGGER.info(STARTUP, integration.version)
+
     cloud = WorxCloud(
         entry.data[CONF_EMAIL],
         entry.data[CONF_PASSWORD],

--- a/custom_components/landroid_cloud/const.py
+++ b/custom_components/landroid_cloud/const.py
@@ -10,6 +10,17 @@ DOMAIN = "landroid_cloud"
 
 PLATFORMS: list[Platform] = [Platform.LAWN_MOWER, Platform.SENSOR]
 
+STARTUP = """
+-------------------------------------------------------------------
+Landroid Cloud integration
+
+Version: %s
+This is a custom integration
+If you have any issues with this you need to open an issue here:
+https://github.com/mtrab/landroid_cloud/issues
+-------------------------------------------------------------------
+"""
+
 CONF_CLOUD = "cloud"
 CONF_COMMAND_TIMEOUT = "command_timeout"
 


### PR DESCRIPTION
## Summary
- add the legacy startup banner constant to modern integration constants
- log the banner during `async_setup_entry` with the integration version

## Testing
- `python -m compileall -q custom_components/landroid_cloud/__init__.py custom_components/landroid_cloud/const.py`
- `ruff check custom_components/landroid_cloud/__init__.py custom_components/landroid_cloud/const.py` *(fails on existing Python 3.12 type-alias syntax in `__init__.py`, unrelated to this change)*
