### PR TITLE
Set Ruff target-version to py314

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,6 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py311"
+target-version = "py314"
 
 select = [
     "B007", # Loop control variable {name} not used within loop body


### PR DESCRIPTION
## Summary
- update `.ruff.toml` target-version from `py311` to `py314`
- align lint parser target with the integration's Python baseline

## Notes
- this PR only changes Ruff parser target; it does not modify existing lint findings

## Testing
- `ruff check custom_components/landroid_cloud/__init__.py` (verifies syntax parsing target now accepts 3.12+ syntax)
