### PR TITLE
Update release drafter translation labels

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -21,6 +21,9 @@ categories:
   - title: '🧰 Maintenance'
     label: 'chore'
 
+  - title: '🌐 Translations'
+    label: 'translation'
+
   - title: ":package: Dependencies"
     labels:
       - 'dependencies'
@@ -58,6 +61,9 @@ autolabeler:
   - label: 'chore'
     branch:
       - '/chore\/.+/'
+  - label: 'translation'
+    branch:
+      - '/translation\/.+/'
   - label: 'dependencies'
     branch:
       - '/dependabot\/.+/'
@@ -66,6 +72,7 @@ autolabeler:
       - '/patch\/.+/'
       - '/dependabot\/.+/'
       - '/chore\/.+/'
+      - '/translation\/.+/'
       - '/feature\/.+/'
       - '/fix\/.+/'
       - '/enhancement\/.+/'


### PR DESCRIPTION
## Summary
- add a dedicated `Translations` release drafter category for the `translation` label
- auto-apply the `translation` label for `translation/*` branches
- auto-apply the `patch` label for `translation/*` branches

## Test strategy
- reviewed the release-drafter YAML diff locally
- verified the new rules match the branch naming convention in `AGENTS.md`

## Known limitations
- no automated tests were run because this is a workflow configuration change

## Configuration changes
- none
