### PR TITLE
Improve issue diagnostics handling

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -80,28 +80,29 @@ body:
     attributes:
       value: |
         # Details
-  - type: textarea
-    validations:
-      required: true
+  - type: upload
     attributes:
-      label: Diagnostics information (NOT log entries!)
-      placeholder: "drag-and-drop the diagnostics data file here (do not copy-and-paste the content)"
+      label: Diagnostics file
       description: >-
-        This integrations provide the ability to [download diagnostic data](https://www.home-assistant.io/docs/configuration/troubleshooting/#debug-logs-and-diagnostics).
+        This integration provides the ability to [download diagnostic data](https://www.home-assistant.io/docs/configuration/troubleshooting/#download-diagnostics).
 
-        **It would really help if you could download the diagnostics data for the device you are having issues with,
-        and <ins>drag-and-drop that file into the textbox below.</ins>**
+        **Please upload the diagnostics JSON file here instead of copy-pasting its content.**
 
         It generally allows pinpointing defects and thus resolving issues faster.
-
-        If you are unable to provide the diagnostics (ie. you cannot add the integration), please write **None** in this field.
+      multiple: false
+  - type: textarea
+    attributes:
+      label: If you could not provide diagnostics, explain why
+      description: >-
+        If you are unable to provide the diagnostics file (for example because you cannot add the integration),
+        explain why here. Otherwise leave this field empty.
   - type: textarea
     validations:
       required: true
     attributes:
       label: Relevant log entries
       description: >-
-        Anything from home-assistant.log that has any direct relevance for this issue
+        Anything from the Home Assistant logs that has any direct relevance for this issue
 
         If you are unable to provide any relevant log entries, please write **None** in this field.
       render: txt

--- a/.github/workflows/issue-auto-labels.yml
+++ b/.github/workflows/issue-auto-labels.yml
@@ -18,6 +18,24 @@ jobs:
           script: |
             const body = context.payload.issue.body ?? "";
             const labels = new Set();
+            const diagnosticsMissingLabel = "diagnostics missing";
+
+            function escapeRegExp(value) {
+              return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            }
+
+            function getSectionValue(heading) {
+              const pattern = new RegExp(
+                `### ${escapeRegExp(heading)}\\s*([\\s\\S]*?)(?=\\n### |$)`,
+                "m",
+              );
+              const match = body.match(pattern);
+              return match ? match[1].trim() : "";
+            }
+
+            function hasMeaningfulValue(value) {
+              return value !== "" && value !== "_No response_";
+            }
 
             const mowerMakeLabels = {
               "Worx Landroid": "Worx Landroid",
@@ -28,7 +46,7 @@ jobs:
 
             for (const [fieldValue, label] of Object.entries(mowerMakeLabels)) {
               const pattern = new RegExp(
-                `### What make of mower does this concern\\?\\s+${fieldValue.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}(?:\\s|$)`,
+                `### What make of mower does this concern\\?\\s+${escapeRegExp(fieldValue)}(?:\\s|$)`,
                 "m",
               );
               if (pattern.test(body)) {
@@ -45,6 +63,52 @@ jobs:
               if (matcher.pattern.test(body)) {
                 labels.add(matcher.label);
               }
+            }
+
+            const diagnosticsFile = getSectionValue("Diagnostics file");
+            const diagnosticsExplanation = getSectionValue(
+              "If you could not provide diagnostics, explain why",
+            );
+
+            const diagnosticsMissing =
+              !hasMeaningfulValue(diagnosticsFile) &&
+              !hasMeaningfulValue(diagnosticsExplanation);
+
+            if (diagnosticsMissing) {
+              labels.add(diagnosticsMissingLabel);
+
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: diagnosticsMissingLabel,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: diagnosticsMissingLabel,
+                  color: "B60205",
+                  description: "Issue is missing diagnostics and no reason was provided",
+                });
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  "Thanks for opening this issue.",
+                  "",
+                  "No diagnostics file was attached, and no explanation was provided for why diagnostics could not be included.",
+                  "Please upload the diagnostics JSON file, or reply with the reason you cannot provide it.",
+                  "You can find the official instructions for downloading diagnostics here: https://www.home-assistant.io/docs/configuration/troubleshooting/#download-diagnostics",
+                ].join("\n"),
+              });
             }
 
             if (labels.size === 0) {


### PR DESCRIPTION
## Summary
- change the bug report form to request diagnostics as an uploaded file instead of pasted JSON
- add a fallback field for users to explain why diagnostics could not be provided
- extend issue auto-labeling to comment and add a `diagnostics missing` label when neither diagnostics nor an explanation is provided

## Test strategy
- validated the updated YAML files locally
- reviewed the workflow logic against the current issue form structure

## Known limitations
- no end-to-end GitHub issue form submission was executed locally
- the diagnostics reminder logic depends on the current issue form heading text staying unchanged

## Configuration changes
- none
