### PR TITLE
Restore bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -89,7 +89,6 @@ body:
         **Please upload the diagnostics JSON file here instead of copy-pasting its content.**
 
         It generally allows pinpointing defects and thus resolving issues faster.
-      multiple: false
   - type: textarea
     attributes:
       label: If you could not provide diagnostics, explain why


### PR DESCRIPTION
## Summary
- remove the invalid `multiple` attribute from the bug issue form upload field
- restore the bug report template so it is selectable again in GitHub

## Test strategy
- validated the issue form YAML locally
- reviewed the template against the current GitHub issue form schema usage in this repository

## Known limitations
- no end-to-end GitHub issue creation flow was executed locally

## Configuration changes
- none
