### PR TITLE
Add rain delay remaining sensor

### DIFF
--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -15,8 +15,10 @@ from homeassistant.const import (
     ATTR_BATTERY_CHARGING,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .entity import LandroidBaseEntity
@@ -35,6 +37,14 @@ def _battery_charging_attribute(device) -> dict[str, bool] | None:
     return None
 
 
+def _rain_delay_remaining_value(device) -> int | None:
+    """Return remaining rain delay in minutes when available."""
+    remaining = getattr(device, "rainsensor", {}).get("remaining")
+    if isinstance(remaining, int):
+        return remaining
+    return None
+
+
 SENSORS: tuple[LandroidSensorDescription, ...] = (
     LandroidSensorDescription(
         key="battery",
@@ -46,6 +56,7 @@ SENSORS: tuple[LandroidSensorDescription, ...] = (
     LandroidSensorDescription(
         key="error",
         translation_key="error",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     LandroidSensorDescription(
         key="rssi",
@@ -53,6 +64,7 @@ SENSORS: tuple[LandroidSensorDescription, ...] = (
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     LandroidSensorDescription(
@@ -66,6 +78,13 @@ SENSORS: tuple[LandroidSensorDescription, ...] = (
         key="next_schedule",
         translation_key="next_schedule",
         entity_registry_enabled_default=False,
+    ),
+    LandroidSensorDescription(
+        key="rain_delay_remaining",
+        translation_key="rain_delay_remaining",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
 )
 
@@ -127,6 +146,8 @@ class LandroidSensor(LandroidBaseEntity, SensorEntity):
             return device.schedules.get("daily_progress")
         if key == "next_schedule":
             return device.schedules.get("next_schedule_start")
+        if key == "rain_delay_remaining":
+            return _rain_delay_remaining_value(device)
 
         return None
 

--- a/custom_components/landroid_cloud/translations/en.json
+++ b/custom_components/landroid_cloud/translations/en.json
@@ -51,6 +51,9 @@
       },
       "next_schedule": {
         "name": "Next schedule"
+      },
+      "rain_delay_remaining": {
+        "name": "Rain delay remaining"
       }
     },
     "binary_sensor": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,8 +3,13 @@
 from types import SimpleNamespace
 
 from homeassistant.const import ATTR_BATTERY_CHARGING
+from homeassistant.helpers.entity import EntityCategory
 
-from custom_components.landroid_cloud.sensor import _battery_charging_attribute
+from custom_components.landroid_cloud.sensor import (
+    SENSORS,
+    _battery_charging_attribute,
+    _rain_delay_remaining_value,
+)
 
 
 def test_battery_charging_attribute_true() -> None:
@@ -35,3 +40,24 @@ def test_rssi_is_read_from_attribute() -> None:
     )
     # Equivalent behavior to sensor native_value branch for key == "rssi".
     assert getattr(device, "rssi", None) == -67
+
+
+def test_rain_delay_remaining_value_returns_minutes() -> None:
+    """Rain delay remaining should be exposed as integer minutes."""
+    device = SimpleNamespace(rainsensor={"remaining": 42})
+    assert _rain_delay_remaining_value(device) == 42
+
+
+def test_rain_delay_remaining_value_unavailable() -> None:
+    """Rain delay remaining should be unknown for non-integer values."""
+    device = SimpleNamespace(rainsensor={"remaining": "42"})
+    assert _rain_delay_remaining_value(device) is None
+
+
+def test_error_and_rssi_are_diagnostic_entities() -> None:
+    """Error and signal strength should be categorized as diagnostics."""
+    error = next(description for description in SENSORS if description.key == "error")
+    rssi = next(description for description in SENSORS if description.key == "rssi")
+
+    assert error.entity_category is EntityCategory.DIAGNOSTIC
+    assert rssi.entity_category is EntityCategory.DIAGNOSTIC


### PR DESCRIPTION
## Summary
- add a sensor for the remaining rain delay in minutes
- categorize the `error` and `signal strength` sensors as diagnostics
- add tests for the new rain delay mapping and diagnostic metadata

## Test strategy
- ran `pytest -q tests/test_sensor.py`

## Known limitations
- the `rain sensor` and `charging` diagnostic category updates were committed separately on `feature/binary-sensor-platform` and are not part of this PR

## Configuration changes
- none
