### PR TITLE
Enable charging binary sensor by default

### DIFF
--- a/custom_components/landroid_cloud/binary_sensor.py
+++ b/custom_components/landroid_cloud/binary_sensor.py
@@ -35,7 +35,6 @@ BINARY_SENSORS: tuple[LandroidBinarySensorDescription, ...] = (
         translation_key="charging",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
     ),
 )
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -16,3 +16,16 @@ def test_rain_sensor_and_charging_are_diagnostic_entities() -> None:
 
     assert rain_sensor.entity_category is EntityCategory.DIAGNOSTIC
     assert charging.entity_category is EntityCategory.DIAGNOSTIC
+
+
+def test_charging_is_enabled_by_default_but_rain_sensor_is_not() -> None:
+    """Charging should be enabled by default while rain sensor stays disabled."""
+    rain_sensor = next(
+        description for description in BINARY_SENSORS if description.key == "rain_sensor"
+    )
+    charging = next(
+        description for description in BINARY_SENSORS if description.key == "charging"
+    )
+
+    assert rain_sensor.entity_registry_enabled_default is False
+    assert charging.entity_registry_enabled_default is True


### PR DESCRIPTION
## Summary
- enable the `charging` binary sensor by default
- keep the `rain sensor` binary sensor disabled by default
- add test coverage for the default enabled/disabled behavior

## Test strategy
- ran `pytest -q tests/test_binary_sensor.py`

## Known limitations
- none

## Configuration changes
- none
