### PR TITLE
Add blade and battery diagnostic sensors

### DIFF
--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -15,6 +15,9 @@ from homeassistant.const import (
     ATTR_BATTERY_CHARGING,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfLength,
+    UnitOfElectricPotential,
+    UnitOfTemperature,
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
@@ -42,6 +45,39 @@ def _rain_delay_remaining_value(device) -> int | None:
     remaining = getattr(device, "rainsensor", {}).get("remaining")
     if isinstance(remaining, int):
         return remaining
+    return None
+
+
+def _battery_cycle_value(device, cycle_key: str) -> int | None:
+    """Return battery cycle information when available."""
+    cycles = getattr(device, "battery", {}).get("cycles", {})
+    value = cycles.get(cycle_key)
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _battery_value(device, battery_key: str) -> float | None:
+    """Return battery telemetry value when available."""
+    value = getattr(device, "battery", {}).get(battery_key)
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def _blade_runtime_value(device, runtime_key: str) -> int | None:
+    """Return blade runtime information in minutes when available."""
+    value = getattr(device, "blades", {}).get(runtime_key)
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _statistics_value(device, statistics_key: str) -> int | None:
+    """Return device statistics value when available."""
+    value = getattr(device, "statistics", {}).get(statistics_key)
+    if isinstance(value, int):
+        return value
     return None
 
 
@@ -83,8 +119,77 @@ SENSORS: tuple[LandroidSensorDescription, ...] = (
         key="rain_delay_remaining",
         translation_key="rain_delay_remaining",
         native_unit_of_measurement=UnitOfTime.MINUTES,
+        suggested_unit_of_measurement=UnitOfTime.HOURS,
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.MEASUREMENT,
+    ),
+    LandroidSensorDescription(
+        key="battery_charge_cycles_total",
+        translation_key="battery_charge_cycles_total",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    LandroidSensorDescription(
+        key="battery_charge_cycles_current",
+        translation_key="battery_charge_cycles_current",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    LandroidSensorDescription(
+        key="battery_temperature",
+        translation_key="battery_temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    LandroidSensorDescription(
+        key="battery_voltage",
+        translation_key="battery_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    LandroidSensorDescription(
+        key="blade_runtime_total",
+        translation_key="blade_runtime_total",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        suggested_unit_of_measurement=UnitOfTime.HOURS,
+        device_class=SensorDeviceClass.DURATION,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    LandroidSensorDescription(
+        key="blade_runtime_current",
+        translation_key="blade_runtime_current",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        suggested_unit_of_measurement=UnitOfTime.HOURS,
+        device_class=SensorDeviceClass.DURATION,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    LandroidSensorDescription(
+        key="distance_driven_total",
+        translation_key="distance_driven_total",
+        native_unit_of_measurement=UnitOfLength.METERS,
+        suggested_unit_of_measurement=UnitOfLength.KILOMETERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    LandroidSensorDescription(
+        key="mower_runtime_total",
+        translation_key="mower_runtime_total",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        suggested_unit_of_measurement=UnitOfTime.HOURS,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
 )
 
@@ -148,6 +253,22 @@ class LandroidSensor(LandroidBaseEntity, SensorEntity):
             return device.schedules.get("next_schedule_start")
         if key == "rain_delay_remaining":
             return _rain_delay_remaining_value(device)
+        if key == "battery_charge_cycles_total":
+            return _battery_cycle_value(device, "total")
+        if key == "battery_charge_cycles_current":
+            return _battery_cycle_value(device, "current")
+        if key == "battery_temperature":
+            return _battery_value(device, "temperature")
+        if key == "battery_voltage":
+            return _battery_value(device, "voltage")
+        if key == "blade_runtime_total":
+            return _blade_runtime_value(device, "total_on")
+        if key == "blade_runtime_current":
+            return _blade_runtime_value(device, "current_on")
+        if key == "distance_driven_total":
+            return _statistics_value(device, "distance")
+        if key == "mower_runtime_total":
+            return _statistics_value(device, "worktime_total")
 
         return None
 

--- a/custom_components/landroid_cloud/translations/en.json
+++ b/custom_components/landroid_cloud/translations/en.json
@@ -54,6 +54,30 @@
       },
       "rain_delay_remaining": {
         "name": "Rain delay remaining"
+      },
+      "battery_charge_cycles_total": {
+        "name": "Battery charge cycles total"
+      },
+      "battery_charge_cycles_current": {
+        "name": "Battery charge cycles since reset"
+      },
+      "battery_temperature": {
+        "name": "Battery temperature"
+      },
+      "battery_voltage": {
+        "name": "Battery voltage"
+      },
+      "blade_runtime_total": {
+        "name": "Blade runtime total"
+      },
+      "blade_runtime_current": {
+        "name": "Blade runtime since reset"
+      },
+      "distance_driven_total": {
+        "name": "Distance driven total"
+      },
+      "mower_runtime_total": {
+        "name": "Mower runtime total"
       }
     },
     "binary_sensor": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -7,8 +7,12 @@ from homeassistant.helpers.entity import EntityCategory
 
 from custom_components.landroid_cloud.sensor import (
     SENSORS,
+    _battery_cycle_value,
     _battery_charging_attribute,
+    _battery_value,
+    _blade_runtime_value,
     _rain_delay_remaining_value,
+    _statistics_value,
 )
 
 
@@ -61,3 +65,57 @@ def test_error_and_rssi_are_diagnostic_entities() -> None:
 
     assert error.entity_category is EntityCategory.DIAGNOSTIC
     assert rssi.entity_category is EntityCategory.DIAGNOSTIC
+
+
+def test_battery_cycle_value_returns_integer() -> None:
+    """Battery cycle values should be exposed when present."""
+    device = SimpleNamespace(battery={"cycles": {"total": 3014, "current": 14}})
+
+    assert _battery_cycle_value(device, "total") == 3014
+    assert _battery_cycle_value(device, "current") == 14
+
+
+def test_blade_runtime_value_returns_minutes() -> None:
+    """Blade runtime values should be exposed in minutes."""
+    device = SimpleNamespace(blades={"total_on": 1200, "current_on": 320})
+
+    assert _blade_runtime_value(device, "total_on") == 1200
+    assert _blade_runtime_value(device, "current_on") == 320
+
+
+def test_battery_value_returns_float() -> None:
+    """Battery telemetry values should be exposed as floats."""
+    device = SimpleNamespace(battery={"temperature": 15.6, "voltage": 20.47})
+
+    assert _battery_value(device, "temperature") == 15.6
+    assert _battery_value(device, "voltage") == 20.47
+
+
+def test_statistics_value_returns_integer() -> None:
+    """Statistics values should be exposed when present."""
+    device = SimpleNamespace(statistics={"distance": 2146986, "worktime_total": 129895})
+
+    assert _statistics_value(device, "distance") == 2146986
+    assert _statistics_value(device, "worktime_total") == 129895
+
+
+def test_blade_and_battery_diagnostic_sensors_are_disabled_by_default() -> None:
+    """Blade and battery diagnostic sensors should be disabled by default."""
+    diagnostic_keys = {
+        "battery_charge_cycles_total",
+        "battery_charge_cycles_current",
+        "battery_temperature",
+        "battery_voltage",
+        "blade_runtime_total",
+        "blade_runtime_current",
+        "distance_driven_total",
+        "mower_runtime_total",
+    }
+    sensors = [description for description in SENSORS if description.key in diagnostic_keys]
+
+    assert len(sensors) == 8
+    assert all(
+        description.entity_category is EntityCategory.DIAGNOSTIC
+        and description.entity_registry_enabled_default is False
+        for description in sensors
+    )


### PR DESCRIPTION
## Summary
- add diagnostic sensors for battery charge cycles, battery voltage, battery temperature, blade runtime, distance driven, and mower runtime
- keep the new diagnostic sensors disabled by default
- suggest `km` for distance and `h` for duration-based sensor display units while preserving native `m` and `min` values

## Test strategy
- ran `pytest -q tests/test_sensor.py`

## Known limitations
- battery charge cycle values currently depend on how `pyworxcloud` reports missing cycle data

## Configuration changes
- none
