### PR TITLE
Model next schedule as timestamp

### DIFF
--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -113,6 +113,7 @@ SENSORS: tuple[LandroidSensorDescription, ...] = (
     LandroidSensorDescription(
         key="next_schedule",
         translation_key="next_schedule",
+        device_class=SensorDeviceClass.TIMESTAMP,
         entity_registry_enabled_default=False,
     ),
     LandroidSensorDescription(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,6 +2,7 @@
 
 from types import SimpleNamespace
 
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import ATTR_BATTERY_CHARGING
 from homeassistant.helpers.entity import EntityCategory
 
@@ -65,6 +66,15 @@ def test_error_and_rssi_are_diagnostic_entities() -> None:
 
     assert error.entity_category is EntityCategory.DIAGNOSTIC
     assert rssi.entity_category is EntityCategory.DIAGNOSTIC
+
+
+def test_next_schedule_is_timestamp_sensor() -> None:
+    """Next schedule should be modeled as a timestamp sensor."""
+    next_schedule = next(
+        description for description in SENSORS if description.key == "next_schedule"
+    )
+
+    assert next_schedule.device_class is SensorDeviceClass.TIMESTAMP
 
 
 def test_battery_cycle_value_returns_integer() -> None:


### PR DESCRIPTION
## Summary
- mark the `next_schedule` sensor as a timestamp sensor
- add test coverage for the timestamp device class

## Test strategy
- ran `pytest -q tests/test_sensor.py`

## Known limitations
- none

## Configuration changes
- none
