### PR TITLE
Expose schedule details on next schedule

### DIFF
--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -81,6 +81,28 @@ def _statistics_value(device, statistics_key: str) -> int | None:
     return None
 
 
+def _schedule_attributes(device) -> dict[str, object] | None:
+    """Return known schedule fields for the next schedule sensor."""
+    schedules = getattr(device, "schedules", None)
+    if not isinstance(schedules, dict):
+        return None
+
+    known_keys = (
+        "active",
+        "time_extension",
+        "slots",
+        "party_mode_enabled",
+        "one_time_schedule",
+        "auto_schedule",
+        "daily_progress",
+        "next_schedule_start",
+    )
+    attributes = {
+        key: schedules[key] for key in known_keys if key in schedules and schedules[key] is not None
+    }
+    return attributes or None
+
+
 SENSORS: tuple[LandroidSensorDescription, ...] = (
     LandroidSensorDescription(
         key="battery",
@@ -274,8 +296,10 @@ class LandroidSensor(LandroidBaseEntity, SensorEntity):
         return None
 
     @property
-    def extra_state_attributes(self) -> dict[str, bool] | None:
-        """Return battery charging attribute for battery sensor."""
-        if self.entity_description.key != "battery":
-            return None
-        return _battery_charging_attribute(self.device)
+    def extra_state_attributes(self) -> dict[str, object] | None:
+        """Return extra state attributes for sensors that expose them."""
+        if self.entity_description.key == "battery":
+            return _battery_charging_attribute(self.device)
+        if self.entity_description.key == "next_schedule":
+            return _schedule_attributes(self.device)
+        return None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -13,6 +13,7 @@ from custom_components.landroid_cloud.sensor import (
     _battery_value,
     _blade_runtime_value,
     _rain_delay_remaining_value,
+    _schedule_attributes,
     _statistics_value,
 )
 
@@ -75,6 +76,33 @@ def test_next_schedule_is_timestamp_sensor() -> None:
     )
 
     assert next_schedule.device_class is SensorDeviceClass.TIMESTAMP
+
+
+def test_schedule_attributes_expose_known_schedule_fields() -> None:
+    """Known schedule fields should be exposed as next schedule attributes."""
+    schedules = {
+        "active": True,
+        "time_extension": 10,
+        "slots": [{"day": "mon", "start": "10:00", "end": "11:00"}],
+        "party_mode_enabled": False,
+        "one_time_schedule": True,
+        "auto_schedule": {"enabled": True, "settings": {"boost": 1}},
+        "daily_progress": 75,
+        "next_schedule_start": "2026-03-12 10:30:00+01:00",
+        "ignored": "value",
+    }
+    device = SimpleNamespace(schedules=schedules)
+
+    assert _schedule_attributes(device) == {
+        "active": True,
+        "time_extension": 10,
+        "slots": [{"day": "mon", "start": "10:00", "end": "11:00"}],
+        "party_mode_enabled": False,
+        "one_time_schedule": True,
+        "auto_schedule": {"enabled": True, "settings": {"boost": 1}},
+        "daily_progress": 75,
+        "next_schedule_start": "2026-03-12 10:30:00+01:00",
+    }
 
 
 def test_battery_cycle_value_returns_integer() -> None:


### PR DESCRIPTION
## Summary\n- expose known schedule snapshot fields as attributes on the next schedule sensor\n- keep the sensor value as the next schedule timestamp\n- add test coverage for the exposed attributes\n\n## Testing\n- pytest -q tests/test_sensor.py\n\n## Known limitations\n- only fields already provided by pyworxcloud are exposed\n