### PR TITLE
Add explicit sensor icons

### DIFF
--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -115,6 +115,7 @@ SENSORS: tuple[LandroidSensorDescription, ...] = (
         key="error",
         translation_key="error",
         entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:alert-circle-outline",
     ),
     LandroidSensorDescription(
         key="rssi",
@@ -131,6 +132,7 @@ SENSORS: tuple[LandroidSensorDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
+        icon="mdi:progress-clock",
     ),
     LandroidSensorDescription(
         key="next_schedule",
@@ -151,12 +153,14 @@ SENSORS: tuple[LandroidSensorDescription, ...] = (
         translation_key="battery_charge_cycles_total",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        icon="mdi:battery-sync",
     ),
     LandroidSensorDescription(
         key="battery_charge_cycles_current",
         translation_key="battery_charge_cycles_current",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        icon="mdi:battery-sync",
     ),
     LandroidSensorDescription(
         key="battery_temperature",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -69,6 +69,16 @@ def test_error_and_rssi_are_diagnostic_entities() -> None:
     assert rssi.entity_category is EntityCategory.DIAGNOSTIC
 
 
+def test_selected_sensors_expose_specific_icons() -> None:
+    """Sensors with ambiguous defaults should expose explicit icons."""
+    descriptions = {description.key: description for description in SENSORS}
+
+    assert descriptions["daily_progress"].icon == "mdi:progress-clock"
+    assert descriptions["battery_charge_cycles_total"].icon == "mdi:battery-sync"
+    assert descriptions["battery_charge_cycles_current"].icon == "mdi:battery-sync"
+    assert descriptions["error"].icon == "mdi:alert-circle-outline"
+
+
 def test_next_schedule_is_timestamp_sensor() -> None:
     """Next schedule should be modeled as a timestamp sensor."""
     next_schedule = next(


### PR DESCRIPTION
## Summary
- add explicit icons for daily progress, error, and battery cycle sensors
- keep the change limited to sensor metadata
- add test coverage for the icon mappings

## Testing
- python -m pytest -q tests/test_sensor.py

## Known limitations
- icon changes are presentation-only and do not affect entity behavior
