### PR TITLE
Refine offline entity availability

### DIFF
--- a/custom_components/landroid_cloud/button.py
+++ b/custom_components/landroid_cloud/button.py
@@ -27,6 +27,7 @@ BUTTONS: tuple[LandroidButtonDescription, ...] = (
         key="edge_cut",
         translation_key="edge_cut",
         icon="mdi:map-marker-path",
+        entity_registry_enabled_default=False,
         capability=DeviceCapability.EDGE_CUT,
     ),
     LandroidButtonDescription(
@@ -78,6 +79,7 @@ class LandroidButton(LandroidBaseEntity, ButtonEntity):
     """Representation of a Landroid cloud button."""
 
     entity_description: LandroidButtonDescription
+    _attr_requires_online = True
 
     def __init__(
         self,

--- a/custom_components/landroid_cloud/entity.py
+++ b/custom_components/landroid_cloud/entity.py
@@ -41,6 +41,7 @@ class LandroidBaseEntity(CoordinatorEntity[LandroidCloudCoordinator]):
     """Base class for all Landroid Cloud entities."""
 
     _attr_has_entity_name = True
+    _attr_requires_online = False
 
     def __init__(
         self,
@@ -62,8 +63,14 @@ class LandroidBaseEntity(CoordinatorEntity[LandroidCloudCoordinator]):
 
     @property
     def available(self) -> bool:
-        """Return availability based on cloud-reported online state."""
-        return bool(getattr(self.device, "online", False))
+        """Return availability for the entity."""
+        if not super().available:
+            return False
+        if self._serial_number not in self.coordinator.data:
+            return False
+        if self._attr_requires_online:
+            return bool(getattr(self.device, "online", False))
+        return True
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/landroid_cloud/lawn_mower.py
+++ b/custom_components/landroid_cloud/lawn_mower.py
@@ -60,6 +60,7 @@ class LandroidCloudMowerEntity(LandroidBaseEntity, LawnMowerEntity):
     """Representation of a cloud mower."""
 
     entity_description = MOWER_DESCRIPTION
+    _attr_requires_online = True
     _attr_supported_features = (
         LawnMowerEntityFeature.START_MOWING
         | LawnMowerEntityFeature.PAUSE

--- a/custom_components/landroid_cloud/number.py
+++ b/custom_components/landroid_cloud/number.py
@@ -107,6 +107,7 @@ class LandroidNumber(LandroidBaseEntity, NumberEntity):
     """Representation of a Landroid cloud number entity."""
 
     entity_description: LandroidNumberDescription
+    _attr_requires_online = True
 
     def __init__(
         self,

--- a/custom_components/landroid_cloud/select.py
+++ b/custom_components/landroid_cloud/select.py
@@ -34,6 +34,7 @@ class LandroidZoneSelect(LandroidBaseEntity, SelectEntity):
 
     _attr_icon = "mdi:map-clock"
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_requires_online = True
     _attr_translation_key = "zone"
 
     def __init__(self, coordinator, config_entry, serial_number: str) -> None:

--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -147,6 +147,7 @@ SENSORS: tuple[LandroidSensorDescription, ...] = (
         suggested_unit_of_measurement=UnitOfTime.HOURS,
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
     LandroidSensorDescription(
         key="battery_charge_cycles_total",

--- a/custom_components/landroid_cloud/switch.py
+++ b/custom_components/landroid_cloud/switch.py
@@ -28,6 +28,7 @@ SWITCHES: tuple[LandroidSwitchDescription, ...] = (
         translation_key="party_mode",
         icon="mdi:party-popper",
         entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
         capability=DeviceCapability.PARTY_MODE,
     ),
     LandroidSwitchDescription(
@@ -93,6 +94,7 @@ class LandroidSwitch(LandroidBaseEntity, SwitchEntity):
     """Representation of a Landroid cloud switch."""
 
     entity_description: LandroidSwitchDescription
+    _attr_requires_online = True
 
     def __init__(
         self,

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -22,3 +22,10 @@ def test_reset_buttons_are_configuration_entities() -> None:
         description.entity_category is EntityCategory.CONFIG
         for description in reset_buttons
     )
+
+
+def test_edge_cut_is_disabled_by_default() -> None:
+    """Edge cut should be disabled by default."""
+    edge_cut = next(description for description in BUTTONS if description.key == "edge_cut")
+
+    assert edge_cut.entity_registry_enabled_default is False

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 
-from custom_components.landroid_cloud.entity import _firmware_version
+from custom_components.landroid_cloud.entity import LandroidBaseEntity, _firmware_version
 
 
 def test_firmware_version_from_dict() -> None:
@@ -21,3 +21,49 @@ def test_firmware_version_defaults_to_unknown() -> None:
     """Missing firmware data should return fallback."""
     device = SimpleNamespace(firmware=None)
     assert _firmware_version(device) == "unknown"
+
+
+class _ReadonlyEntity(LandroidBaseEntity):
+    """Minimal readonly entity for availability tests."""
+
+
+class _WritableEntity(LandroidBaseEntity):
+    """Minimal writable entity for availability tests."""
+
+    _attr_requires_online = True
+
+
+def test_readonly_entity_stays_available_when_device_is_offline() -> None:
+    """Readonly entities should stay available with cached offline data."""
+    entity = object.__new__(_ReadonlyEntity)
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data={"serial": SimpleNamespace(online=False)},
+    )
+    entity._serial_number = "serial"
+
+    assert entity.available is True
+
+
+def test_writable_entity_becomes_unavailable_when_device_is_offline() -> None:
+    """Writable entities should be unavailable while device is offline."""
+    entity = object.__new__(_WritableEntity)
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data={"serial": SimpleNamespace(online=False)},
+    )
+    entity._serial_number = "serial"
+
+    assert entity.available is False
+
+
+def test_entities_are_unavailable_when_coordinator_data_is_stale() -> None:
+    """Coordinator update failures should still mark all entities unavailable."""
+    entity = object.__new__(_ReadonlyEntity)
+    entity.coordinator = SimpleNamespace(
+        last_update_success=False,
+        data={"serial": SimpleNamespace(online=True)},
+    )
+    entity._serial_number = "serial"
+
+    assert entity.available is False

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -167,3 +167,12 @@ def test_blade_and_battery_diagnostic_sensors_are_disabled_by_default() -> None:
         and description.entity_registry_enabled_default is False
         for description in sensors
     )
+
+
+def test_rain_delay_remaining_is_disabled_by_default() -> None:
+    """Rain delay remaining should be disabled by default."""
+    rain_delay_remaining = next(
+        description for description in SENSORS if description.key == "rain_delay_remaining"
+    )
+
+    assert rain_delay_remaining.entity_registry_enabled_default is False

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -11,3 +11,12 @@ def test_switches_are_configuration_entities() -> None:
         description.entity_category is EntityCategory.CONFIG
         for description in SWITCHES
     )
+
+
+def test_party_mode_is_disabled_by_default() -> None:
+    """Party mode should be disabled by default."""
+    party_mode = next(
+        description for description in SWITCHES if description.key == "party_mode"
+    )
+
+    assert party_mode.entity_registry_enabled_default is False


### PR DESCRIPTION
## Summary
- keep read-only entities available when a mower goes offline so status and errors remain visible
- mark writable entities unavailable while the mower is offline
- disable party mode, edge cut, and rain delay remaining by default

## Testing
- python -m pytest -q tests/test_button.py tests/test_sensor.py tests/test_switch.py tests/test_entity.py

## Known limitations
- availability still depends on coordinator freshness, so stale coordinator data marks all entities unavailable
