### PR TITLE
Bump pyworxcloud to 6.0.2

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -13,7 +13,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud==6.0.1"
+        "pyworxcloud==6.0.2"
     ],
     "version": "6.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytest-asyncio==1.3.0
 pytest-cov==7.0.0
 pip>=21.0,<26.1
 ruff==0.15.5
-pyworxcloud==6.0.0
+pyworxcloud==6.0.2


### PR DESCRIPTION
## Summary
Update the integration to use pyworxcloud 6.0.2 in both the Home Assistant manifest and local development requirements.

## Testing
- No functional test run; this change only updates package versions.

## Known limitations
- None beyond the normal dependency upgrade risk.
