### PR TITLE
Skip zero-duration next schedule slots

### DIFF
--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -23,6 +25,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from pyworxcloud.day_map import DAY_MAP
 
 from .entity import LandroidBaseEntity
 
@@ -98,9 +101,64 @@ def _schedule_attributes(device) -> dict[str, object] | None:
         "next_schedule_start",
     )
     attributes = {
-        key: schedules[key] for key in known_keys if key in schedules and schedules[key] is not None
+        key: schedules[key]
+        for key in known_keys
+        if key in schedules and schedules[key] is not None
     }
+    corrected_next = _next_schedule_value(device)
+    if corrected_next is not None:
+        attributes["next_schedule_start"] = corrected_next
     return attributes or None
+
+
+def _resolve_timezone(device) -> timezone | ZoneInfo:
+    """Return the device timezone or UTC fallback."""
+    tz_name = getattr(device, "time_zone", None)
+    if tz_name is None:
+        return timezone.utc
+    try:
+        return ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        return timezone.utc
+
+
+def _next_schedule_value(device) -> datetime | None:
+    """Return the next future slot with a non-zero duration."""
+    schedules = getattr(device, "schedules", None)
+    if not isinstance(schedules, dict):
+        return None
+
+    slots = schedules.get("slots", []) or []
+    if not isinstance(slots, list):
+        return schedules.get("next_schedule_start")
+
+    tzinfo = _resolve_timezone(device)
+    now = datetime.now(tzinfo)
+    candidates: list[datetime] = []
+
+    for offset in range(0, 14):
+        target_date = now + timedelta(days=offset)
+        day = DAY_MAP[int(target_date.strftime("%w"))]
+        for slot in slots:
+            if slot.get("day") != day:
+                continue
+            if int(slot.get("duration_extended", 0)) <= 0:
+                continue
+            start_value = slot.get("start")
+            if not isinstance(start_value, str):
+                continue
+            start = datetime.strptime(
+                f"{target_date.strftime('%d/%m/%Y')} {start_value}:00",
+                "%d/%m/%Y %H:%M:%S",
+            ).replace(tzinfo=tzinfo)
+            if offset == 0 and start <= now:
+                continue
+            candidates.append(start)
+
+    if candidates:
+        return min(candidates)
+
+    return schedules.get("next_schedule_start")
 
 
 SENSORS: tuple[LandroidSensorDescription, ...] = (
@@ -278,7 +336,7 @@ class LandroidSensor(LandroidBaseEntity, SensorEntity):
         if key == "daily_progress":
             return device.schedules.get("daily_progress")
         if key == "next_schedule":
-            return device.schedules.get("next_schedule_start")
+            return _next_schedule_value(device)
         if key == "rain_delay_remaining":
             return _rain_delay_remaining_value(device)
         if key == "battery_charge_cycles_total":

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,17 +1,21 @@
 """Tests for Landroid sensors."""
 
+from datetime import datetime
 from types import SimpleNamespace
+from zoneinfo import ZoneInfo
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import ATTR_BATTERY_CHARGING
 from homeassistant.helpers.entity import EntityCategory
 
+import custom_components.landroid_cloud.sensor as sensor_module
 from custom_components.landroid_cloud.sensor import (
     SENSORS,
     _battery_cycle_value,
     _battery_charging_attribute,
     _battery_value,
     _blade_runtime_value,
+    _next_schedule_value,
     _rain_delay_remaining_value,
     _schedule_attributes,
     _statistics_value,
@@ -115,6 +119,49 @@ def test_schedule_attributes_expose_known_schedule_fields() -> None:
     }
 
 
+def test_next_schedule_skips_zero_duration_slots(monkeypatch) -> None:
+    """Zero-duration slots should not be exposed as the next schedule."""
+    real_datetime = sensor_module.datetime
+
+    class FrozenDateTime:
+        """Minimal datetime shim returning a fixed current time."""
+
+        @staticmethod
+        def now(tz=None):
+            return real_datetime(2026, 3, 12, 10, 30, tzinfo=tz or ZoneInfo("UTC"))
+
+        strptime = staticmethod(real_datetime.strptime)
+
+    monkeypatch.setattr(sensor_module, "datetime", FrozenDateTime)
+
+    device = SimpleNamespace(
+        time_zone="UTC",
+        schedules={
+            "slots": [
+                {
+                    "day": "thursday",
+                    "start": "11:00",
+                    "end": "11:00",
+                    "duration": 0,
+                    "duration_extended": 0,
+                },
+                {
+                    "day": "thursday",
+                    "start": "15:00",
+                    "end": "15:30",
+                    "duration": 30,
+                    "duration_extended": 30,
+                },
+            ],
+            "next_schedule_start": datetime(2026, 3, 12, 11, 0, tzinfo=ZoneInfo("UTC")),
+        },
+    )
+
+    assert _next_schedule_value(device) == datetime(
+        2026, 3, 12, 15, 0, tzinfo=ZoneInfo("UTC")
+    )
+
+
 def test_battery_cycle_value_returns_integer() -> None:
     """Battery cycle values should be exposed when present."""
     device = SimpleNamespace(battery={"cycles": {"total": 3014, "current": 14}})
@@ -159,7 +206,9 @@ def test_blade_and_battery_diagnostic_sensors_are_disabled_by_default() -> None:
         "distance_driven_total",
         "mower_runtime_total",
     }
-    sensors = [description for description in SENSORS if description.key in diagnostic_keys]
+    sensors = [
+        description for description in SENSORS if description.key in diagnostic_keys
+    ]
 
     assert len(sensors) == 8
     assert all(
@@ -172,7 +221,9 @@ def test_blade_and_battery_diagnostic_sensors_are_disabled_by_default() -> None:
 def test_rain_delay_remaining_is_disabled_by_default() -> None:
     """Rain delay remaining should be disabled by default."""
     rain_delay_remaining = next(
-        description for description in SENSORS if description.key == "rain_delay_remaining"
+        description
+        for description in SENSORS
+        if description.key == "rain_delay_remaining"
     )
 
     assert rain_delay_remaining.entity_registry_enabled_default is False


### PR DESCRIPTION
## Summary
- recalculate the exposed next schedule in the integration and ignore zero-duration slots
- keep the next-schedule sensor and its attributes aligned when empty slots exist in the source payload
- add regression coverage for the zero-duration case

## Test strategy
- `python3 -m pytest -q tests/test_sensor.py`
- `python3 -m py_compile custom_components/landroid_cloud/sensor.py tests/test_sensor.py`

## Known limitations
- this changes Home Assistant presentation only; it does not alter the underlying schedule payload from the cloud

## Configuration changes
- none