### PR TITLE
Add legacy OTS service

### DIFF
--- a/custom_components/landroid_cloud/lawn_mower.py
+++ b/custom_components/landroid_cloud/lawn_mower.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import voluptuous as vol
 from homeassistant.components.lawn_mower import (
     LawnMowerActivity,
     LawnMowerEntity,
@@ -12,7 +13,10 @@ from homeassistant.components.lawn_mower import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers import entity_platform
+from pyworxcloud.exceptions import NoOneTimeScheduleError
 
 from .commands import async_run_cloud_command
 from .entity import LandroidBaseEntity
@@ -40,6 +44,9 @@ STATUS_ACTIVITY_MAP: Final[dict[int, LawnMowerActivity]] = {
     104: LawnMowerActivity.RETURNING,
 }
 MOWER_DESCRIPTION: Final = LawnMowerEntityEntityDescription(key="mower")
+SERVICE_OTS: Final = "ots"
+ATTR_BOUNDARY: Final = "boundary"
+ATTR_RUNTIME: Final = "runtime"
 
 
 async def async_setup_entry(
@@ -49,6 +56,17 @@ async def async_setup_entry(
 ) -> None:
     """Set up Landroid Cloud lawn mower entities."""
     coordinator = entry.runtime_data.coordinator
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_OTS,
+        {
+            vol.Required(ATTR_BOUNDARY): bool,
+            vol.Required(ATTR_RUNTIME): vol.All(
+                vol.Coerce(int), vol.Range(min=10, max=120)
+            ),
+        },
+        "_async_service_ots",
+    )
 
     async_add_entities(
         LandroidCloudMowerEntity(coordinator, entry, serial_number)
@@ -101,3 +119,18 @@ class LandroidCloudMowerEntity(LandroidBaseEntity, LawnMowerEntity):
         await async_run_cloud_command(
             lambda: self.coordinator.cloud.home(str(self.device.serial_number))
         )
+
+    async def _async_service_ots(self, boundary: bool, runtime: int) -> None:
+        """Handle legacy OTS service call."""
+        try:
+            await async_run_cloud_command(
+                lambda: self.coordinator.cloud.ots(
+                    str(self.device.serial_number), boundary, runtime
+                )
+            )
+        except HomeAssistantError as err:
+            if isinstance(err.__cause__, NoOneTimeScheduleError):
+                raise HomeAssistantError(
+                    "Mower does not support one-time schedule"
+                ) from err
+            raise

--- a/custom_components/landroid_cloud/services.yaml
+++ b/custom_components/landroid_cloud/services.yaml
@@ -1,0 +1,28 @@
+ots:
+  description: Start One-Time-Schedule (if supported)
+  target:
+    entity:
+      integration: landroid_cloud
+      domain: lawn_mower
+  fields:
+    boundary:
+      name: Boundary
+      description: Do boundary (Edge cut)
+      example: true
+      required: true
+      default: false
+      selector:
+        boolean:
+    runtime:
+      name: Run time
+      description: Run time in minutes
+      example: 60
+      required: true
+      default: 30
+      selector:
+        number:
+          min: 10
+          max: 120
+          step: 1
+          unit_of_measurement: "minutes"
+          mode: slider

--- a/tests/test_lawn_mower.py
+++ b/tests/test_lawn_mower.py
@@ -1,8 +1,15 @@
 """Tests for mower activity mapping."""
 
-from homeassistant.components.lawn_mower import LawnMowerActivity
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
-from custom_components.landroid_cloud.lawn_mower import STATUS_ACTIVITY_MAP
+from homeassistant.components.lawn_mower import LawnMowerActivity
+import pytest
+
+from custom_components.landroid_cloud.lawn_mower import (
+    STATUS_ACTIVITY_MAP,
+    LandroidCloudMowerEntity,
+)
 
 
 def test_start_sequence_states_map_to_mowing() -> None:
@@ -16,3 +23,18 @@ def test_unknown_state_defaults_to_error() -> None:
     assert (
         STATUS_ACTIVITY_MAP.get(999, LawnMowerActivity.ERROR) is LawnMowerActivity.ERROR
     )
+
+
+@pytest.mark.asyncio
+async def test_ots_service_calls_cloud_ots() -> None:
+    """OTS service should call the cloud command with legacy arguments."""
+    entity = object.__new__(LandroidCloudMowerEntity)
+    entity._serial_number = "serial"
+    entity.coordinator = SimpleNamespace(
+        cloud=SimpleNamespace(ots=AsyncMock()),
+        data={"serial": SimpleNamespace(serial_number="serial")},
+    )
+
+    await entity._async_service_ots(boundary=True, runtime=45)
+
+    entity.coordinator.cloud.ots.assert_awaited_once_with("serial", True, 45)


### PR DESCRIPTION
## Summary
- restore the legacy-compatible OTS service
- keep the legacy service layout with boundary and runtime fields
- route the service through the current mower/coordinator command path

## Test strategy
- python3 -m pytest -q tests/test_lawn_mower.py
- python3 -m py_compile custom_components/landroid_cloud/lawn_mower.py tests/test_lawn_mower.py

## Known limitations
- only the OTS service is restored in this change

## Configuration changes
- no manual configuration changes required