### PR TITLE
Add missing translations for error states and config flow

### DIFF
--- a/custom_components/landroid_cloud/config_flow.py
+++ b/custom_components/landroid_cloud/config_flow.py
@@ -8,6 +8,7 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 from pyworxcloud import WorxCloud
 from pyworxcloud.exceptions import (
     APIException,
@@ -36,8 +37,11 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_EMAIL): str,
         vol.Required(CONF_PASSWORD): str,
-        vol.Required(CONF_CLOUD, default=DEFAULT_CLOUD): vol.In(
-            ["worx", "kress", "landxcape"]
+        vol.Required(CONF_CLOUD, default=DEFAULT_CLOUD): SelectSelector(
+            SelectSelectorConfig(
+                options=["worx", "kress", "landxcape"],
+                translation_key="cloud",
+            )
         ),
     }
 )

--- a/custom_components/landroid_cloud/const.py
+++ b/custom_components/landroid_cloud/const.py
@@ -44,3 +44,45 @@ class CloudProvider(StrEnum):
     WORX = "worx"
     KRESS = "kress"
     LANDXCAPE = "landxcape"
+
+
+ERROR_STATE_MAP: dict[int, str] = {
+    -1: "unknown",
+    0: "no_error",
+    1: "trapped",
+    2: "lifted",
+    3: "wire_missing",
+    4: "outside_wire",
+    5: "rain_delay",
+    6: "close_door_to_mow",
+    7: "close_door_to_go_home",
+    8: "blade_motor_blocked",
+    9: "wheel_motor_blocked",
+    10: "trapped_timeout",
+    11: "upside_down",
+    12: "battery_low",
+    13: "reverse_wire",
+    14: "charge_error",
+    15: "timeout_finding_home",
+    16: "locked",
+    17: "battery_temperature_error",
+    19: "battery_trunk_open_timeout",
+    20: "wire_sync",
+    100: "charging_station_docking_error",
+    101: "hbi_error",
+    102: "ota_error",
+    103: "map_error",
+    104: "excessive_slope",
+    105: "unreachable_zone",
+    106: "unreachable_charging_station",
+    108: "insufficient_sensor_data",
+    109: "training_start_disallowed",
+    110: "camera_error",
+    111: "mapping_exploration_required",
+    112: "mapping_exploration_failed",
+    113: "rfid_reader_error",
+    114: "headlight_error",
+    115: "missing_charging_station",
+    116: "blade_height_adjustment_blocked",
+}
+ERROR_STATE_OPTIONS: tuple[str, ...] = tuple(dict.fromkeys(ERROR_STATE_MAP.values()))

--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from pyworxcloud.day_map import DAY_MAP
 
+from .const import ERROR_STATE_MAP, ERROR_STATE_OPTIONS
 from .entity import LandroidBaseEntity
 
 
@@ -188,6 +189,8 @@ SENSORS: tuple[LandroidSensorDescription, ...] = (
     LandroidSensorDescription(
         key="error",
         translation_key="error",
+        device_class=SensorDeviceClass.ENUM,
+        options=ERROR_STATE_OPTIONS,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:alert-circle-outline",
     ),
@@ -370,7 +373,7 @@ class LandroidSensor(LandroidBaseEntity, SensorEntity):
         if key == "battery":
             return device.battery.get("percent")
         if key == "error":
-            return device.error.get("description")
+            return ERROR_STATE_MAP.get(device.error.get("id", -1), "unknown")
         if key == "rssi":
             return getattr(device, "rssi", None)
         if key == "daily_progress":

--- a/custom_components/landroid_cloud/translations/en.json
+++ b/custom_components/landroid_cloud/translations/en.json
@@ -2,7 +2,8 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to Landroid Cloud",
+        "title": "Connect to cloud services",
+        "description": "Enter your cloud credentials and select your cloud provider.",
         "data": {
           "email": "Email",
           "password": "Password",
@@ -20,6 +21,15 @@
     },
     "abort": {
       "already_exists": "This account is already configured"
+    }
+  },
+  "selector": {
+    "cloud": {
+      "options": {
+        "worx": "Worx",
+        "kress": "Kress",
+        "landxcape": "LandXcape"
+      }
     }
   },
   "options": {
@@ -41,7 +51,46 @@
         "name": "Status"
       },
       "error": {
-        "name": "Error"
+        "name": "Error",
+        "state": {
+          "unknown": "Unknown",
+          "no_error": "No error",
+          "trapped": "Trapped",
+          "lifted": "Lifted",
+          "wire_missing": "Wire missing",
+          "outside_wire": "Outside wire",
+          "rain_delay": "Rain delay active",
+          "close_door_to_mow": "Close door to mow",
+          "close_door_to_go_home": "Close door to go home",
+          "blade_motor_blocked": "Blade motor is blocked",
+          "wheel_motor_blocked": "Wheel motor is blocked",
+          "trapped_timeout": "Timed out while trapped",
+          "upside_down": "Mower is upside down",
+          "battery_low": "Battery low",
+          "reverse_wire": "Wire is reversed",
+          "charge_error": "Error charging",
+          "timeout_finding_home": "Timed out while finding home",
+          "locked": "Mower is locked",
+          "battery_temperature_error": "Battery temperature error",
+          "battery_trunk_open_timeout": "Battery trunk open timeout",
+          "wire_sync": "Wire sync",
+          "charging_station_docking_error": "Charging station docking error",
+          "hbi_error": "HBI error",
+          "ota_error": "OTA error",
+          "map_error": "Map error",
+          "excessive_slope": "Excessive slope detected",
+          "unreachable_zone": "Unreachable zone",
+          "unreachable_charging_station": "Unreachable charging station",
+          "insufficient_sensor_data": "Insufficient sensor data",
+          "training_start_disallowed": "Training start disallowed",
+          "camera_error": "Camera error",
+          "mapping_exploration_required": "Mapping exploration required",
+          "mapping_exploration_failed": "Mapping exploration failed",
+          "rfid_reader_error": "RFID reader error",
+          "headlight_error": "Headlight error",
+          "missing_charging_station": "Missing charging station",
+          "blade_height_adjustment_blocked": "Blade height adjustment blocked"
+        }
       },
       "rssi": {
         "name": "Signal strength"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,14 @@
+"""Tests for Landroid Cloud config flow schema."""
+
+from homeassistant.helpers.selector import SelectSelector
+
+from custom_components.landroid_cloud.config_flow import STEP_USER_DATA_SCHEMA
+
+
+def test_cloud_selector_uses_translated_labels() -> None:
+    """Cloud selector should expose translation-backed option labels."""
+    selector = STEP_USER_DATA_SCHEMA.schema["cloud"]
+
+    assert isinstance(selector, SelectSelector)
+    assert selector.config["translation_key"] == "cloud"
+    assert selector.config["options"] == ["worx", "kress", "landxcape"]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.const import ATTR_BATTERY_CHARGING
 from homeassistant.helpers.entity import EntityCategory
 
 import custom_components.landroid_cloud.sensor as sensor_module
+from custom_components.landroid_cloud.const import ERROR_STATE_MAP, ERROR_STATE_OPTIONS
 from custom_components.landroid_cloud.sensor import (
     SENSORS,
     _battery_cycle_value,
@@ -66,6 +67,13 @@ def test_rain_delay_remaining_value_unavailable() -> None:
     assert _rain_delay_remaining_value(device) is None
 
 
+def test_error_state_mapping_uses_stable_tokens() -> None:
+    """Error states should map from numeric ids to translation tokens."""
+    assert ERROR_STATE_MAP[0] == "no_error"
+    assert ERROR_STATE_MAP[110] == "camera_error"
+    assert ERROR_STATE_MAP.get(999, "unknown") == "unknown"
+
+
 def test_error_and_rssi_are_diagnostic_entities() -> None:
     """Error and signal strength should be categorized as diagnostics."""
     error = next(description for description in SENSORS if description.key == "error")
@@ -73,6 +81,17 @@ def test_error_and_rssi_are_diagnostic_entities() -> None:
 
     assert error.entity_category is EntityCategory.DIAGNOSTIC
     assert rssi.entity_category is EntityCategory.DIAGNOSTIC
+
+
+def test_error_is_enum_sensor_with_translated_state_tokens() -> None:
+    """Error should expose stable enum tokens for translation."""
+    error = next(description for description in SENSORS if description.key == "error")
+
+    assert error.device_class is SensorDeviceClass.ENUM
+    assert error.options == ERROR_STATE_OPTIONS
+    assert "no_error" in error.options
+    assert "camera_error" in error.options
+    assert "unknown" in error.options
 
 
 def test_selected_sensors_expose_specific_icons() -> None:


### PR DESCRIPTION
## Summary
- add translated labels for cloud provider choices in config flow
- expose mower error as enum sensor with translated state values
- move error state constants into const.py and add focused tests

## Test strategy
- `python3 -m pytest -q tests/test_sensor.py tests/test_config_flow.py`
- `python3 -m json.tool custom_components/landroid_cloud/translations/en.json`

## Known limitations
- translations are only added for English in this change

## Configuration changes
- none