### PR TITLE
Bump pyworxcloud to 6.0.4

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -13,7 +13,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud==6.0.3"
+        "pyworxcloud==6.0.4"
     ],
     "version": "6.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytest-asyncio==1.3.0
 pytest-cov==7.0.0
 pip>=21.0,<26.1
 ruff==0.15.5
-pyworxcloud==6.0.3
+pyworxcloud==6.0.4


### PR DESCRIPTION
## Summary
- bump `pyworxcloud` to `6.0.4` in the integration manifest
- bump `pyworxcloud` to `6.0.4` in local development requirements

## Test strategy
- no functional tests run; this change only updates dependency versions

## Known limitations
- none

## Configuration changes
- none