### PR TITLE
Prepare v7 breaking changes notes

### DIFF
--- a/docs/release-notes-v7-breaking-changes.md
+++ b/docs/release-notes-v7-breaking-changes.md
@@ -20,7 +20,6 @@ The main breaking areas are:
 The legacy integration exposed service calls that are not present in the new version:
 
 - `landroid_cloud.config`
-- `landroid_cloud.ots`
 - `landroid_cloud.schedule`
 - `landroid_cloud.send_raw`
 


### PR DESCRIPTION
## Summary
- add an internal draft document with the known v7 breaking changes
- capture migration notes for the legacy-to-v7 rewrite

## Test strategy
- documentation only

## Known limitations
- this is release-preparation documentation and may still be refined before final release notes

## Configuration changes
- none