### PR TITLE
Prepare v7 breaking changes notes

### DIFF
--- a/docs/release-notes-v7-breaking-changes.md
+++ b/docs/release-notes-v7-breaking-changes.md
@@ -1,0 +1,129 @@
+# Release Notes Prep: v7 Breaking Changes
+
+This note is intended as internal release-notes preparation for the v7 rewrite.
+
+## Summary
+
+The new integration is not a drop-in replacement for the legacy version.
+The main breaking areas are:
+
+- legacy services are no longer exposed
+- many entity keys changed
+- several entities were removed
+- many configuration and diagnostic entities are now disabled by default
+- write-capable entities are unavailable while the mower is offline
+
+## Breaking Changes
+
+### Removed legacy services
+
+The legacy integration exposed service calls that are not present in the new version:
+
+- `landroid_cloud.config`
+- `landroid_cloud.ots`
+- `landroid_cloud.schedule`
+- `landroid_cloud.send_raw`
+
+Automations or scripts calling those services will break.
+
+### Entity ID and unique ID churn
+
+The new integration uses a different entity model and several entity keys have changed.
+Because unique IDs are derived from `serial_number + entity_key`, Home Assistant will treat these as new entities.
+
+Expected impact:
+
+- dashboards will show missing entities
+- automations and scripts targeting old entity IDs will break
+- users may need to reassign entities manually in dashboards/helpers
+
+### Entity renames
+
+Known high-impact renames:
+
+- `partymode` -> `party_mode`
+- `locked` -> `lock`
+- `offlimits` -> `off_limits`
+- `offlimits_shortcut` -> `off_limits_shortcut`
+- `zoneselect` -> `zone`
+- `raindelay` -> `rain_delay`
+- `timeextension` -> `time_extension`
+- `battery_charging` -> `charging`
+- `rainsensor_triggered` -> `rain_sensor`
+- `battery_state` -> `battery`
+- `next_start` -> `next_schedule`
+- `battery_cycles_total` -> `battery_charge_cycles_total`
+- `battery_cycles_current` -> `battery_charge_cycles_current`
+- `blades_reset_at` -> `blade_runtime_reset_at`
+- `blades_reset_time` -> `blade_runtime_reset_time`
+- `distance` -> `distance_driven_total`
+- `worktime_total` -> `mower_runtime_total`
+- `edgecut` -> `edge_cut`
+- `reset_charge_cycles` -> `reset_battery_cycles`
+
+### Removed entities
+
+The following legacy entities are not present in the current version:
+
+- `online` binary sensor
+- `request_update` button
+- `restart` button
+- `pitch` sensor
+- `roll` sensor
+- `yaw` sensor
+
+### Disabled by default
+
+Many configuration and diagnostic entities are now disabled by default.
+This is intentional, but users may interpret it as missing functionality after upgrade.
+
+Examples include:
+
+- zone select
+- last update
+- rain delay
+- cutting height
+- time extension
+- torque
+- party mode
+- lock
+- rain sensor
+- next schedule
+- blade runtime reset at
+- blade runtime reset time
+- most diagnostic sensors
+
+### Availability changes
+
+Write-capable entities are now unavailable while the mower is offline.
+Read-only entities stay available so users can still inspect state and diagnostics.
+
+This is safer behavior, but it changes how automations behave when devices are offline.
+
+### RTK/Vision zone handling
+
+RTK-style zones can now be read correctly, but write support is still not implemented for RTK zone selection.
+
+Expected impact:
+
+- users can see current/available RTK zones
+- users cannot reliably change RTK zone from Home Assistant yet
+
+## Migration Notes
+
+Users upgrading from legacy should be told to:
+
+1. review broken or unavailable entities after upgrade
+2. re-enable desired disabled-by-default entities manually
+3. update automations/scripts to use the new entity IDs
+4. remove or rewrite any automations using the removed legacy services
+
+## Notes For Final Release Post
+
+Recommended release-note sections:
+
+- breaking changes
+- removed services
+- renamed entities
+- disabled-by-default entities
+- migration guidance

--- a/docs/release-notes-v7-breaking-changes.md
+++ b/docs/release-notes-v7-breaking-changes.md
@@ -35,6 +35,12 @@ The rewrite now exposes these custom services instead:
 - `landroid_cloud.add_schedule`
 - `landroid_cloud.edit_schedule`
 - `landroid_cloud.delete_schedule`
+- `landroid_cloud.set_exclusion_day`
+- `landroid_cloud.add_exclusion_schedule`
+- `landroid_cloud.edit_exclusion_schedule`
+- `landroid_cloud.delete_exclusion_schedule`
+- `landroid_cloud.set_nutrition`
+- `landroid_cloud.clear_nutrition`
 
 This means old automations cannot be migrated by a simple rename.
 Schedule-related automations must be rewritten to use the new service names and field structure.
@@ -58,6 +64,7 @@ The current model includes detailed states such as:
 - `edgecut`
 - `zoning`
 - `searching_zone`
+- `rain_delayed`
 - `escaped_digital_fence`
 
 This reduces the migration gap versus legacy, but users should still verify any automation that depends on exact state names.
@@ -106,6 +113,20 @@ Known high-impact renames:
 - `worktime_total` -> `mower_runtime_total`
 - `edgecut` -> `edge_cut`
 - `reset_charge_cycles` -> `reset_battery_cycles`
+- `pause_mode` -> `party_mode`
+
+### New auto-schedule entity model
+
+The v7 rewrite now exposes auto-schedule controls as native Home Assistant entities instead of leaving them to app-only workflows.
+
+New entity areas include:
+
+- an `auto_schedule` switch plus related irrigation and exclude-night switches
+- auto-schedule tuning selects for boost, grass type, and soil type
+- auto-schedule nutrition and exclusion summary sensors
+- additional writable lawn metadata numbers such as lawn size and perimeter
+
+This improves coverage, but it also means more entity IDs and more disabled-by-default configuration entities for users to review after upgrade.
 
 ### Removed entities
 
@@ -128,11 +149,16 @@ Examples include:
 - cutting height
 - time extension
 - torque
-- pause mode
+- auto schedule
+- party mode
+- auto schedule irrigation
+- auto schedule exclude nights
 - lock
 - ACS
 - rain sensor
 - next schedule
+- auto schedule nutrition
+- auto schedule exclusion schedules
 - pitch
 - roll
 - yaw
@@ -149,6 +175,15 @@ Expected impact:
 
 - automations checking for a timestamp value should also handle `unavailable`
 - dashboards may now show no upcoming schedule more explicitly
+
+### Rain delay behavior changed
+
+The lawn mower entity and device automations now expose a dedicated `rain_delayed` state when the mower is still inside an active rain-delay countdown.
+
+Expected impact:
+
+- automations that previously only watched `docked` or generic idle-like states may need to include `rain_delayed`
+- users can now distinguish between a normal docked mower and one that is still waiting for rain delay to expire
 
 ### Availability changes
 
@@ -176,7 +211,9 @@ Users upgrading from legacy should be told to:
 4. update automations/scripts to use the new entity IDs
 5. remove or rewrite any automations using the removed legacy services
 6. rewrite schedule automations to use the new `landroid_cloud.add_schedule`, `landroid_cloud.edit_schedule`, and `landroid_cloud.delete_schedule` services
-7. update any automation using `next_schedule` so it handles `unavailable`
+7. review whether any app-only auto-schedule workflows should move to the new auto-schedule entities and exclusion/nutrition services
+8. update any automation using `next_schedule` so it handles `unavailable`
+9. update any automation that keys off mower states so it can handle `rain_delayed` where relevant
 
 ## Notes For Final Release Post
 
@@ -185,6 +222,8 @@ Recommended release-note sections:
 - breaking changes
 - removed services
 - new schedule service model
+- new auto-schedule entities and services
 - renamed entities
+- mower state changes
 - disabled-by-default entities
 - migration guidance

--- a/docs/release-notes-v7-breaking-changes.md
+++ b/docs/release-notes-v7-breaking-changes.md
@@ -20,7 +20,6 @@ The main breaking areas are:
 The legacy integration exposed service calls that are not present in the new version:
 
 - `landroid_cloud.config`
-- `landroid_cloud.ots`
 - `landroid_cloud.schedule`
 - `landroid_cloud.send_raw`
 

--- a/docs/release-notes-v7-breaking-changes.md
+++ b/docs/release-notes-v7-breaking-changes.md
@@ -88,7 +88,6 @@ Expected impact:
 
 Known high-impact renames:
 
-- `partymode` -> `pause_mode`
 - `locked` -> `lock`
 - `offlimits` -> `off_limits`
 - `offlimits_shortcut` -> `off_limits_shortcut`

--- a/docs/release-notes-v7-breaking-changes.md
+++ b/docs/release-notes-v7-breaking-changes.md
@@ -60,7 +60,7 @@ Expected impact:
 
 Known high-impact renames:
 
-- `partymode` -> `party_mode`
+- `partymode` -> `pause_mode`
 - `locked` -> `lock`
 - `offlimits` -> `off_limits`
 - `offlimits_shortcut` -> `off_limits_shortcut`
@@ -104,7 +104,7 @@ Examples include:
 - cutting height
 - time extension
 - torque
-- party mode
+- pause mode
 - lock
 - rain sensor
 - next schedule

--- a/docs/release-notes-v7-breaking-changes.md
+++ b/docs/release-notes-v7-breaking-changes.md
@@ -89,7 +89,7 @@ Examples include:
 - lock
 - rain sensor
 - next schedule
-- blade runtime reset at
+- blade runtime at last reset
 - blade runtime reset time
 - most diagnostic sensors
 

--- a/docs/release-notes-v7-breaking-changes.md
+++ b/docs/release-notes-v7-breaking-changes.md
@@ -8,6 +8,7 @@ The new integration is not a drop-in replacement for the legacy version.
 The main breaking areas are:
 
 - legacy services are no longer exposed
+- new service names and payloads must be used for schedule management
 - many entity keys changed
 - several entities were removed
 - many configuration and diagnostic entities are now disabled by default
@@ -24,6 +25,25 @@ The legacy integration exposed service calls that are not present in the new ver
 - `landroid_cloud.send_raw`
 
 Automations or scripts calling those services will break.
+
+### New custom service model
+
+The rewrite now exposes these custom services instead:
+
+- `landroid_cloud.ots`
+- `landroid_cloud.add_schedule`
+- `landroid_cloud.edit_schedule`
+- `landroid_cloud.delete_schedule`
+
+This means old automations cannot be migrated by a simple rename.
+Schedule-related automations must be rewritten to use the new service names and field structure.
+
+Key behavior differences:
+
+- schedule creation now uses `days`, `start`, `duration`, and optional `boundary`
+- schedule editing now targets an existing entry with `current_day` and optional `current_start`
+- schedule deletion now uses `day` and optional `start`, or `all_schedules: true`
+- the old generic schedule payload format is no longer used
 
 ### Entity ID and unique ID churn
 
@@ -92,6 +112,16 @@ Examples include:
 - blade runtime reset time
 - most diagnostic sensors
 
+### Next schedule behavior changed
+
+`next_schedule` now becomes unavailable when the mower has no valid upcoming schedule.
+Users coming from older behavior may previously have seen stale, misleading, or `unknown` values instead.
+
+Expected impact:
+
+- automations checking for a timestamp value should also handle `unavailable`
+- dashboards may now show no upcoming schedule more explicitly
+
 ### Availability changes
 
 Write-capable entities are now unavailable while the mower is offline.
@@ -116,6 +146,8 @@ Users upgrading from legacy should be told to:
 2. re-enable desired disabled-by-default entities manually
 3. update automations/scripts to use the new entity IDs
 4. remove or rewrite any automations using the removed legacy services
+5. rewrite schedule automations to use the new `landroid_cloud.add_schedule`, `landroid_cloud.edit_schedule`, and `landroid_cloud.delete_schedule` services
+6. update any automation using `next_schedule` so it handles `unavailable`
 
 ## Notes For Final Release Post
 
@@ -123,6 +155,7 @@ Recommended release-note sections:
 
 - breaking changes
 - removed services
+- new schedule service model
 - renamed entities
 - disabled-by-default entities
 - migration guidance

--- a/docs/release-notes-v7-breaking-changes.md
+++ b/docs/release-notes-v7-breaking-changes.md
@@ -11,6 +11,7 @@ The main breaking areas are:
 - new service names and payloads must be used for schedule management
 - many entity keys changed
 - several entities were removed
+- legacy config entries now migrate forward automatically, but the stored data format changed
 - many configuration and diagnostic entities are now disabled by default
 - write-capable entities are unavailable while the mower is offline
 
@@ -55,6 +56,17 @@ Expected impact:
 - dashboards will show missing entities
 - automations and scripts targeting old entity IDs will break
 - users may need to reassign entities manually in dashboards/helpers
+
+### Config entry data changed
+
+The stored config entry format changed in v7.
+Older entries used the legacy `type` field and older unique ID patterns, while the new version stores a canonical `cloud` value and a new unique ID format.
+
+Expected impact:
+
+- existing v6 entries should now migrate automatically during setup
+- manual delete-and-recreate should no longer be the normal upgrade path
+- users with unusual or conflicting old unique IDs may still need manual cleanup if Home Assistant already has a collision
 
 ### Entity renames
 
@@ -106,6 +118,7 @@ Examples include:
 - torque
 - pause mode
 - lock
+- ACS
 - rain sensor
 - next schedule
 - blade runtime at last reset
@@ -142,12 +155,13 @@ Expected impact:
 
 Users upgrading from legacy should be told to:
 
-1. review broken or unavailable entities after upgrade
-2. re-enable desired disabled-by-default entities manually
-3. update automations/scripts to use the new entity IDs
-4. remove or rewrite any automations using the removed legacy services
-5. rewrite schedule automations to use the new `landroid_cloud.add_schedule`, `landroid_cloud.edit_schedule`, and `landroid_cloud.delete_schedule` services
-6. update any automation using `next_schedule` so it handles `unavailable`
+1. allow the integration to migrate the existing config entry before attempting manual cleanup
+2. review broken or unavailable entities after upgrade
+3. re-enable desired disabled-by-default entities manually
+4. update automations/scripts to use the new entity IDs
+5. remove or rewrite any automations using the removed legacy services
+6. rewrite schedule automations to use the new `landroid_cloud.add_schedule`, `landroid_cloud.edit_schedule`, and `landroid_cloud.delete_schedule` services
+7. update any automation using `next_schedule` so it handles `unavailable`
 
 ## Notes For Final Release Post
 

--- a/docs/release-notes-v7-breaking-changes.md
+++ b/docs/release-notes-v7-breaking-changes.md
@@ -38,6 +38,7 @@ The rewrite now exposes these custom services instead:
 
 This means old automations cannot be migrated by a simple rename.
 Schedule-related automations must be rewritten to use the new service names and field structure.
+Native device automations are available again for mower actions, conditions, and triggers, so the breaking change mainly affects automations that called the removed legacy services directly.
 
 Key behavior differences:
 
@@ -45,6 +46,21 @@ Key behavior differences:
 - schedule editing now targets an existing entry with `current_day` and optional `current_start`
 - schedule deletion now uses `day` and optional `start`, or `all_schedules: true`
 - the old generic schedule payload format is no longer used
+
+### Mower state model changed
+
+The mower entity still uses the v7 lawn mower platform, but detailed runtime states are exposed again where the cloud data supports them.
+
+The current model includes detailed states such as:
+
+- `idle`
+- `starting`
+- `edgecut`
+- `zoning`
+- `searching_zone`
+- `escaped_digital_fence`
+
+This reduces the migration gap versus legacy, but users should still verify any automation that depends on exact state names.
 
 ### Entity ID and unique ID churn
 
@@ -99,9 +115,6 @@ The following legacy entities are not present in the current version:
 - `online` binary sensor
 - `request_update` button
 - `restart` button
-- `pitch` sensor
-- `roll` sensor
-- `yaw` sensor
 
 ### Disabled by default
 
@@ -121,6 +134,9 @@ Examples include:
 - ACS
 - rain sensor
 - next schedule
+- pitch
+- roll
+- yaw
 - blade runtime at last reset
 - blade runtime reset time
 - most diagnostic sensors


### PR DESCRIPTION
## Summary
- add an internal draft document with the known v7 breaking changes
- capture migration notes for the legacy-to-v7 rewrite

## Test strategy
- documentation only

## Known limitations
- this is release-preparation documentation and may still be refined before final release notes

## Configuration changes
- none