### PR TITLE
Refresh integration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,15 @@ Each mower creates one lawn mower entity with these actions:
 | Daily progress | Standard | Disabled |
 | Next schedule | Standard | Disabled |
 | Rain delay remaining | Standard | Disabled |
+| Last update | Standard | Disabled |
 | Battery charge cycles total | Diagnostic | Disabled |
 | Battery charge cycles since reset | Diagnostic | Disabled |
 | Battery temperature | Diagnostic | Disabled |
 | Battery voltage | Diagnostic | Disabled |
 | Blade runtime total | Diagnostic | Disabled |
 | Blade runtime since reset | Diagnostic | Disabled |
+| Blade runtime reset at | Diagnostic | Disabled |
+| Blade runtime reset time | Diagnostic | Disabled |
 | Distance driven total | Diagnostic | Disabled |
 | Mower runtime total | Diagnostic | Disabled |
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Each mower creates one lawn mower entity with these actions:
 | Signal strength | Diagnostic | Disabled |
 | Daily progress | Standard | Disabled |
 | Next schedule | Standard | Disabled |
+| Auto schedule nutrition | Standard | Disabled |
+| Auto schedule exclusion schedules | Standard | Disabled |
 | Rain delay remaining | Standard | Disabled |
 | Last update | Standard | Disabled |
 | Battery charge cycles total | Diagnostic | Disabled |
@@ -103,6 +105,8 @@ Each mower creates one lawn mower entity with these actions:
 Notes:
 
 - `Next schedule` is exposed as a timestamp sensor and includes known schedule details as attributes.
+- `Auto schedule nutrition` exposes the configured N/P/K values when auto schedule provides them.
+- `Auto schedule exclusion schedules` summarizes exclusion rules and exposes the normalized schedule details as attributes.
 - `Rain delay remaining` is only available while a rain delay is active. When the mower reports `0` minutes remaining, the sensor is exposed as unavailable instead of reporting `0`.
 - Duration and distance sensors suggest user-friendly display units where Home Assistant supports conversion.
 
@@ -119,7 +123,10 @@ All switches are configuration entities and require the mower to be online.
 
 | Entity | Default | Notes |
 | --- | --- | --- |
-| Pause mode | Disabled | Requires pause mode support |
+| Auto schedule | Disabled | |
+| Party mode | Disabled | Requires party mode support |
+| Auto schedule irrigation | Disabled | Requires auto schedule to be enabled |
+| Auto schedule exclude nights | Disabled | Requires auto schedule to be enabled |
 | Lock | Disabled | |
 | Off Limits | Enabled | Requires Off Limits support |
 | Off Limits shortcuts | Enabled | Requires Off Limits support |
@@ -145,12 +152,17 @@ Numbers require the mower to be online and are disabled by default.
 | Cutting height | Configuration | 20-70 mm | 1 | Requires cutting height support |
 | Time extension | Configuration | -100% to 100% | 10 | |
 | Torque | Configuration | -50% to 50% | 1 | Requires torque support |
+| Lawn size | Configuration | 0-100000 m² | 1 | |
+| Lawn perimeter | Configuration | 0-100000 m | 1 | |
 
 #### Selects
 
 | Entity | Category | Default | Notes |
 | --- | --- | --- | --- |
 | Zone | Configuration | Disabled | Requires mower to be online |
+| Auto schedule boost | Configuration | Disabled | Requires auto schedule to be enabled |
+| Auto schedule grass type | Configuration | Disabled | Requires auto schedule to be enabled |
+| Auto schedule soil type | Configuration | Disabled | Requires auto schedule to be enabled |
 
 ## Actions and control model
 
@@ -159,19 +171,25 @@ The integration exposes control through native entities and custom `landroid_clo
 - Lawn mower actions for start, pause and dock
 - Device automations for mower actions, triggers, and conditions in Home Assistant automations
 - Buttons for one-shot actions such as edge cut and counter resets
-- Switches for boolean features such as ACS, lock and Off Limits
-- Numbers for writable values such as rain delay, cutting height, time extension and torque
-- Select for zone choice
+- Switches for boolean features such as auto schedule, party mode, ACS, lock and Off Limits
+- Numbers for writable values such as rain delay, cutting height, time extension, torque and lawn metadata
+- Select entities for zone choice and auto-schedule tuning
 - The `landroid_cloud.ots` service for starting a one-time schedule
 - The `landroid_cloud.add_schedule`, `landroid_cloud.edit_schedule`, and `landroid_cloud.delete_schedule` services for schedule management
+- Additional auto-schedule services for nutrition and exclusion schedule management
 
-Supported device automation states include mowing, docked, returning, error, edge cut, starting, zoning, searching for zone, idle, and escaped digital fence.
+Supported device automation states include mowing, docked, returning, error, edge cut, starting, zoning, searching for zone, idle, rain delayed, and escaped digital fence.
 
 ### Auto-schedule refresh behavior
 
 Auto-schedule settings are written through observed mower API calls, not through the MQTT push channel used for many runtime updates.
 
 Because of that, changes made from Home Assistant do not appear immediately in the vendor app, and changes made in the vendor app do not appear immediately in Home Assistant. Updated values become visible after the next API refresh cycle.
+
+### Zone handling
+
+Legacy mowers expose the configured start-point zones for selection.
+RTK/Vision style zone IDs are exposed read-only, and changing the selected RTK zone from Home Assistant is not supported yet.
 
 ### Custom integration services
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@
 
 # Landroid Cloud
 
-This integration is designed for Home Assistant.
+This is a Home Assistant integration for cloud-connected Landroid mowers.
 
-Landroid Cloud lets you connect your cloud-compatible mower to Home Assistant.
-
-### Currently these vendors are supported:
+### Supported vendors
 
 - Worx Landroid
 - Kress
@@ -19,18 +17,18 @@ Landroid Cloud lets you connect your cloud-compatible mower to Home Assistant.
 ### HACS
 
 - Ensure that HACS is installed.
-- Search for and install the `Landroid Cloud` integration (or click the blue button below to go there directly).
+- Search for `Landroid Cloud` and install it, or use the button below.
 - Restart Home Assistant.
-- Go to Integrations and add the Landroid Cloud integration
+- Go to Integrations and add `Landroid Cloud`.
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=MTrab&repository=landroid_cloud)
 
 ### Manual installation
 
 - Download the latest release.
-- Unpack the release and copy the custom_components/landroid_cloud directory into the custom_components directory of your Home Assistant installation.
+- Unpack it and copy `custom_components/landroid_cloud` into your Home Assistant `custom_components` directory.
 - Restart Home Assistant.
-- Go to Integrations and add the Landroid Cloud integration
+- Go to Integrations and add `Landroid Cloud`.
 
 ## Setup
 
@@ -38,25 +36,25 @@ Open the integration setup directly:
 
 [![](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=landroid_cloud)
 
-Or go to `Home Assistant` > `Settings` > `Devices & services`
+Or go to `Home Assistant` > `Settings` > `Devices & services`.
 
-Add the `Landroid Cloud` integration _(If it doesn't show, try CTRL+F5 to force a refresh of the page)_
+Add `Landroid Cloud`. If it doesn't show up, try `CTRL+F5` to refresh the page.
 
 Use the same credentials as in your mower app.
 
-If you are upgrading from v6, existing config entries should now migrate into v7 automatically instead of requiring a full remove and re-add.
+If you're upgrading from v6, existing config entries should migrate to v7 automatically. You shouldn't need to remove and add the integration again.
 
-## Landroid Card
+## Landroid card
 
 [Barma-lej](https://github.com/barma-lej) has created a custom card for the Landroid Cloud integration.<br/>
-You can find installation instructions on [this Github repo](https://github.com/Barma-lej/landroid-card)
+Installation instructions are in [the GitHub repository](https://github.com/Barma-lej/landroid-card).
 
 
 ## Integration overview
 
-The integration exposes each mower as a Home Assistant device with a native lawn mower entity and a set of related entities for telemetry, diagnostics and configuration.
+Each mower is added as a Home Assistant device. The integration creates a native lawn mower entity plus related entities for status, diagnostics, and configuration.
 
-Write-capable entities become unavailable while the mower is offline. Read-only entities remain available so status and diagnostics can still be inspected.
+Entities that can change mower settings go unavailable while the mower is offline. Read-only entities stay available, so you can still see status and diagnostics.
 
 ### Supported vendors
 
@@ -64,10 +62,15 @@ Write-capable entities become unavailable while the mower is offline. Read-only 
 - Kress
 - LandXcape
 
-Fleet is not supported at the moment.
-The Fleet API is still in an early alpha state, so this integration does not currently expose Fleet devices or controls.
+Fleet is not supported right now.
+The Fleet API is still in early alpha, so this integration does not expose Fleet devices or controls.
 
-### Exposed entities
+### Known limitations
+
+On Kress RTK Mission and Landroid Vision mowers, zones and schedules are read-only in this integration.
+They can be read from the mower, but they cannot be changed from Home Assistant.
+
+### Entities
 
 #### Lawn mower
 
@@ -107,10 +110,10 @@ Each mower creates one lawn mower entity with these actions:
 
 Notes:
 
-- `Next schedule` is exposed as a timestamp sensor and includes known schedule details as attributes.
+- `Next schedule` is a timestamp sensor and includes known schedule details as attributes.
 - `Auto schedule nutrition` exposes the configured N/P/K values when auto schedule provides them.
 - `Auto schedule exclusion schedules` summarizes exclusion rules and exposes the normalized schedule details as attributes.
-- `Rain delay remaining` is only available while a rain delay is active. When the mower reports `0` minutes remaining, the sensor is exposed as unavailable instead of reporting `0`.
+- `Rain delay remaining` is only available while a rain delay is active. When the mower reports `0` minutes left, the sensor becomes unavailable instead of showing `0`.
 - Duration and distance sensors suggest user-friendly display units where Home Assistant supports conversion.
 
 #### Binary sensors
@@ -122,7 +125,7 @@ Notes:
 
 #### Updates
 
-Firmware updates are exposed through a native Home Assistant update entity when the mower reports OTA firmware support.
+If the mower reports OTA firmware support, firmware updates are exposed through a native Home Assistant update entity.
 
 | Entity | Category | Default | Notes |
 | --- | --- | --- | --- |
@@ -131,8 +134,8 @@ Firmware updates are exposed through a native Home Assistant update entity when 
 Notes:
 
 - The update entity exposes the installed version, the latest available version, and release notes when the cloud API provides them.
-- Release notes prefer the Markdown-friendly changelog from the API when available.
-- Installing an update queues the latest available firmware from the vendor cloud. Older firmware versions cannot be selected manually.
+- If the API provides a Markdown-friendly changelog, that version is used for release notes.
+- Installing an update queues the latest available firmware from the vendor cloud. You can't pick an older version manually.
 
 #### Switches
 
@@ -182,16 +185,16 @@ Numbers require the mower to be online and are disabled by default.
 | Auto schedule grass type | Configuration | Disabled | Requires auto schedule to be enabled |
 | Auto schedule soil type | Configuration | Disabled | Requires auto schedule to be enabled |
 
-## Actions and control model
+## Control and services
 
-The integration exposes control through native entities and custom `landroid_cloud` services:
+You can control the mower through native entities and custom `landroid_cloud` services:
 
-- Lawn mower actions for start, pause and dock
-- Device automations for mower actions, triggers, and conditions in Home Assistant automations
-- Update entities for firmware version tracking, release notes, and OTA install actions
+- Lawn mower actions for start, pause, and dock
+- Device automations for mower actions, triggers, and conditions
+- Update entities for firmware version tracking, release notes, and OTA installs
 - Buttons for one-shot actions such as edge cut and counter resets
-- Switches for boolean features such as auto schedule, firmware auto update, party mode, ACS, lock and Off Limits
-- Numbers for writable values such as rain delay, cutting height, time extension, torque and lawn metadata
+- Switches for boolean features such as auto schedule, firmware auto update, party mode, ACS, lock, and Off Limits
+- Numbers for writable values such as rain delay, cutting height, time extension, torque, and lawn metadata
 - Select entities for zone choice and auto-schedule tuning
 - The `landroid_cloud.ots` service for starting a one-time schedule
 - The `landroid_cloud.add_schedule`, `landroid_cloud.edit_schedule`, and `landroid_cloud.delete_schedule` services for schedule management
@@ -201,20 +204,22 @@ Supported device automation states include mowing, docked, returning, error, edg
 
 ### Auto-schedule refresh behavior
 
-Auto-schedule settings are written through observed mower API calls, not through the MQTT push channel used for many runtime updates.
+Auto-schedule settings are written through observed mower API calls, not through the MQTT push channel used for many live updates.
 
-Because of that, changes made from Home Assistant do not appear immediately in the vendor app, and changes made in the vendor app do not appear immediately in Home Assistant. Updated values become visible after the next API refresh cycle.
+That means changes made in Home Assistant do not show up right away in the vendor app, and changes made in the vendor app do not show up right away in Home Assistant. Updated values appear after the next API refresh.
+
+On Kress RTK Mission and Landroid Vision mowers, schedules are read-only. The integration can show them, but it cannot create, edit, or delete them.
 
 ### Zone handling
 
-Legacy mowers expose the configured start-point zones for selection.
-RTK/Vision style zone IDs are exposed read-only, and changing the selected RTK zone from Home Assistant is not supported yet.
+Legacy mowers expose their configured start-point zones for selection.
+RTK/Vision-style zone IDs are exposed as read-only. Changing the selected RTK zone from Home Assistant is not supported yet.
 
 ### Firmware updates
 
 Firmware update metadata is read from the vendor cloud API and merged with the mower's live firmware payload when available.
 
-Because availability and release notes come from cloud lookups instead of the normal push updates, Home Assistant may show new firmware details only after the next refresh or when the update entity explicitly refreshes its metadata.
+Because availability and release notes come from cloud lookups instead of the usual push updates, Home Assistant may only show new firmware details after the next refresh or when the update entity refreshes its metadata.
 
 ### Custom integration services
 
@@ -242,7 +247,7 @@ data:
 
 #### `landroid_cloud.add_schedule`
 
-Creates one or more recurring schedule entries in a single action call.
+Creates one or more recurring schedule entries in a single action.
 
 Fields:
 
@@ -254,8 +259,8 @@ Fields:
 Behavior:
 
 - If you select multiple days, the same schedule is created for each selected day
-- On mowers with two slots per day, the integration automatically chooses the first or second free slot
-- On mowers that support more than two daily entries, the integration will keep adding entries on the selected day as long as the mower accepts them
+- On mowers with two slots per day, the integration picks the first or second free slot automatically
+- On mowers that support more than two daily entries, the integration keeps adding entries on the selected day as long as the mower accepts them
 
 Example:
 
@@ -290,7 +295,7 @@ Behavior:
 
 - If the selected current day only has one schedule, `current_start` is not needed
 - If the day has multiple schedules, you must provide `current_start` so the integration knows which one to edit
-- When moving an entry to a different day, the integration automatically resolves the correct slot behind the scenes
+- When moving an entry to a different day, the integration resolves the correct slot automatically
 
 Example:
 
@@ -342,26 +347,28 @@ data:
   all_schedules: true
 ```
 
-### Finding the right schedule to edit or delete
+### Finding the schedule you want to edit or delete
 
-Enable the `Next schedule` sensor if you want a simple view of the normalized schedule data the integration uses. Its attributes include `schedule_entries`, which can help you see which days and start times currently exist for the mower.
+Enable the `Next schedule` sensor if you want an easy way to inspect the normalized schedule data used by the integration. Its attributes include `schedule_entries`, which can help you see which days and start times currently exist for the mower.
 
 ## Availability behavior
 
 - Read-only entities stay available when the mower is offline
-- Write-capable entities are marked unavailable when the mower is offline
-- If coordinator data itself is unavailable, all related entities become unavailable
+- Entities that can change mower settings are marked unavailable when the mower is offline
+- If coordinator data is unavailable, all related entities become unavailable
 
 ## Diagnostics and issue reporting
 
-If you open an issue, include a Home Assistant diagnostics download whenever possible. Diagnostics are much more useful than pasted JSON fragments or screenshots of attributes.
+If you open an issue, include a Home Assistant diagnostics download when possible. It is usually much more useful than pasted JSON fragments or screenshots of attributes.
 
 ## Other useful information
+
 ### Services and app stopped working
 
-You might experience being banned from Worx Landroid Cloud service.
-Follow this simple guide to make it work again:
-* Go to [My Landroids](https://account.worxlandroid.com/product-items)
-* Unlink your Landroid(s)
-* Open app on mobile device
-* Add Landroid(s)
+You may have been temporarily blocked by the Worx Landroid cloud service.
+To restore access:
+
+- Go to [My Landroids](https://account.worxlandroid.com/product-items)
+- Unlink your Landroid(s)
+- Open the mobile app
+- Add the Landroid(s) again

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Add the `Landroid Cloud` integration _(If it doesn't show, try CTRL+F5 to force 
 
 Use the same credentials as in your mower app.
 
+If you are upgrading from v6, existing config entries should now migrate into v7 automatically instead of requiring a full remove and re-add.
+
 ## Landroid Card
 
 [Barma-lej](https://github.com/barma-lej) has created a custom card for the Landroid Cloud integration.<br/>
@@ -117,7 +119,7 @@ All switches are configuration entities and require the mower to be online.
 | Lock | Disabled | |
 | Off Limits | Enabled | Requires Off Limits support |
 | Off Limits shortcuts | Enabled | Requires Off Limits support |
-| ACS | Enabled | Requires ACS support |
+| ACS | Disabled | Requires ACS support |
 
 #### Buttons
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Numbers require the mower to be online and are disabled by default.
 | Rain delay | Configuration | 0-300 min | 1 | |
 | Cutting height | Configuration | 20-70 mm | 1 | Requires cutting height support |
 | Time extension | Configuration | -100% to 100% | 10 | |
+| Torque | Configuration | -50% to 50% | 1 | Requires torque support |
 
 #### Selects
 
@@ -149,7 +150,7 @@ The integration does not add custom Home Assistant services. Control is exposed 
 - Lawn mower actions for start, pause and dock
 - Buttons for one-shot actions such as edge cut and counter resets
 - Switches for boolean features such as ACS, lock and Off Limits
-- Numbers for writable values such as rain delay, cutting height and time extension
+- Numbers for writable values such as rain delay, cutting height, time extension and torque
 - Select for zone choice
 
 ## Availability behavior

--- a/README.md
+++ b/README.md
@@ -148,21 +148,21 @@ Numbers require the mower to be online and are disabled by default.
 
 ## Actions and control model
 
-The integration exposes control through native entities and custom `lawn_mower` actions:
+The integration exposes control through native entities and custom `landroid_cloud` services:
 
 - Lawn mower actions for start, pause and dock
 - Buttons for one-shot actions such as edge cut and counter resets
 - Switches for boolean features such as ACS, lock and Off Limits
 - Numbers for writable values such as rain delay, cutting height, time extension and torque
 - Select for zone choice
-- The `lawn_mower.ots` action for starting a one-time schedule
-- The `lawn_mower.add_schedule`, `lawn_mower.edit_schedule`, and `lawn_mower.delete_schedule` actions for schedule management
+- The `landroid_cloud.ots` service for starting a one-time schedule
+- The `landroid_cloud.add_schedule`, `landroid_cloud.edit_schedule`, and `landroid_cloud.delete_schedule` services for schedule management
 
-### Custom lawn mower actions
+### Custom integration services
 
-All custom actions target a `lawn_mower` entity from this integration.
+All custom services target a `lawn_mower` entity from this integration.
 
-#### `lawn_mower.ots`
+#### `landroid_cloud.ots`
 
 Starts a one-time mowing session on mowers that support it.
 
@@ -174,7 +174,7 @@ Fields:
 Example:
 
 ```yaml
-action: lawn_mower.ots
+action: landroid_cloud.ots
 target:
   entity_id: lawn_mower.my_landroid
 data:
@@ -182,7 +182,7 @@ data:
   runtime: 45
 ```
 
-#### `lawn_mower.add_schedule`
+#### `landroid_cloud.add_schedule`
 
 Creates one or more recurring schedule entries in a single action call.
 
@@ -202,7 +202,7 @@ Behavior:
 Example:
 
 ```yaml
-action: lawn_mower.add_schedule
+action: landroid_cloud.add_schedule
 target:
   entity_id: lawn_mower.my_landroid
 data:
@@ -215,7 +215,7 @@ data:
   boundary: false
 ```
 
-#### `lawn_mower.edit_schedule`
+#### `landroid_cloud.edit_schedule`
 
 Updates one existing schedule entry.
 
@@ -237,7 +237,7 @@ Behavior:
 Example:
 
 ```yaml
-action: lawn_mower.edit_schedule
+action: landroid_cloud.edit_schedule
 target:
   entity_id: lawn_mower.my_landroid
 data:
@@ -249,7 +249,7 @@ data:
   boundary: true
 ```
 
-#### `lawn_mower.delete_schedule`
+#### `landroid_cloud.delete_schedule`
 
 Deletes one schedule entry or clears the whole schedule.
 
@@ -268,7 +268,7 @@ Behavior:
 Examples:
 
 ```yaml
-action: lawn_mower.delete_schedule
+action: landroid_cloud.delete_schedule
 target:
   entity_id: lawn_mower.my_landroid
 data:
@@ -277,7 +277,7 @@ data:
 ```
 
 ```yaml
-action: lawn_mower.delete_schedule
+action: landroid_cloud.delete_schedule
 target:
   entity_id: lawn_mower.my_landroid
 data:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Each mower creates one lawn mower entity with these actions:
 | Battery voltage | Diagnostic | Disabled |
 | Blade runtime total | Diagnostic | Disabled |
 | Blade runtime since reset | Diagnostic | Disabled |
-| Blade runtime reset at | Diagnostic | Disabled |
+| Blade runtime at last reset | Diagnostic | Disabled |
 | Blade runtime reset time | Diagnostic | Disabled |
 | Distance driven total | Diagnostic | Disabled |
 | Mower runtime total | Diagnostic | Disabled |

--- a/README.md
+++ b/README.md
@@ -148,13 +148,14 @@ Numbers require the mower to be online and are disabled by default.
 
 ## Actions and control model
 
-The integration does not add custom Home Assistant services. Control is exposed through native entities instead:
+The integration exposes control through native entities and one legacy-compatible service:
 
 - Lawn mower actions for start, pause and dock
 - Buttons for one-shot actions such as edge cut and counter resets
 - Switches for boolean features such as ACS, lock and Off Limits
 - Numbers for writable values such as rain delay, cutting height, time extension and torque
 - Select for zone choice
+- The `landroid_cloud.ots` service for starting a one-time schedule with boundary and runtime parameters
 
 ## Availability behavior
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ The integration exposes control through native entities and custom `landroid_clo
 
 Supported device automation states include mowing, docked, returning, error, edge cut, starting, zoning, searching for zone, idle, and escaped digital fence.
 
+### Auto-schedule refresh behavior
+
+Auto-schedule settings are written through observed mower API calls, not through the MQTT push channel used for many runtime updates.
+
+Because of that, changes made from Home Assistant do not appear immediately in the vendor app, and changes made in the vendor app do not appear immediately in Home Assistant. Updated values become visible after the next API refresh cycle.
+
 ### Custom integration services
 
 All custom services target a `lawn_mower` entity from this integration.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Each mower creates one lawn mower entity with these actions:
 Notes:
 
 - `Next schedule` is exposed as a timestamp sensor and includes known schedule details as attributes.
+- `Rain delay remaining` is only available while a rain delay is active. When the mower reports `0` minutes remaining, the sensor is exposed as unavailable instead of reporting `0`.
 - Duration and distance sensors suggest user-friendly display units where Home Assistant supports conversion.
 
 #### Binary sensors

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Each mower creates one lawn mower entity with these actions:
 | Battery charge cycles since reset | Diagnostic | Disabled |
 | Battery temperature | Diagnostic | Disabled |
 | Battery voltage | Diagnostic | Disabled |
+| Pitch | Diagnostic | Disabled |
+| Roll | Diagnostic | Disabled |
+| Yaw | Diagnostic | Disabled |
 | Blade runtime total | Diagnostic | Disabled |
 | Blade runtime since reset | Diagnostic | Disabled |
 | Blade runtime at last reset | Diagnostic | Disabled |
@@ -154,12 +157,15 @@ Numbers require the mower to be online and are disabled by default.
 The integration exposes control through native entities and custom `landroid_cloud` services:
 
 - Lawn mower actions for start, pause and dock
+- Device automations for mower actions, triggers, and conditions in Home Assistant automations
 - Buttons for one-shot actions such as edge cut and counter resets
 - Switches for boolean features such as ACS, lock and Off Limits
 - Numbers for writable values such as rain delay, cutting height, time extension and torque
 - Select for zone choice
 - The `landroid_cloud.ots` service for starting a one-time schedule
 - The `landroid_cloud.add_schedule`, `landroid_cloud.edit_schedule`, and `landroid_cloud.delete_schedule` services for schedule management
+
+Supported device automation states include mowing, docked, returning, error, edge cut, starting, zoning, searching for zone, idle, and escaped digital fence.
 
 ### Custom integration services
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Write-capable entities become unavailable while the mower is offline. Read-only 
 - Kress
 - LandXcape
 
+Fleet is not supported at the moment.
+The Fleet API is still in an early alpha state, so this integration does not currently expose Fleet devices or controls.
+
 ### Exposed entities
 
 #### Lawn mower
@@ -117,6 +120,20 @@ Notes:
 | Charging | Diagnostic | Enabled |
 | Rain sensor | Diagnostic | Disabled |
 
+#### Updates
+
+Firmware updates are exposed through a native Home Assistant update entity when the mower reports OTA firmware support.
+
+| Entity | Category | Default | Notes |
+| --- | --- | --- | --- |
+| Firmware | Standard | Enabled | Requires OTA firmware support |
+
+Notes:
+
+- The update entity exposes the installed version, the latest available version, and release notes when the cloud API provides them.
+- Release notes prefer the Markdown-friendly changelog from the API when available.
+- Installing an update queues the latest available firmware from the vendor cloud. Older firmware versions cannot be selected manually.
+
 #### Switches
 
 All switches are configuration entities and require the mower to be online.
@@ -124,6 +141,7 @@ All switches are configuration entities and require the mower to be online.
 | Entity | Default | Notes |
 | --- | --- | --- |
 | Auto schedule | Disabled | |
+| Firmware auto update | Disabled | Requires OTA firmware support |
 | Party mode | Disabled | Requires party mode support |
 | Auto schedule irrigation | Disabled | Requires auto schedule to be enabled |
 | Auto schedule exclude nights | Disabled | Requires auto schedule to be enabled |
@@ -170,8 +188,9 @@ The integration exposes control through native entities and custom `landroid_clo
 
 - Lawn mower actions for start, pause and dock
 - Device automations for mower actions, triggers, and conditions in Home Assistant automations
+- Update entities for firmware version tracking, release notes, and OTA install actions
 - Buttons for one-shot actions such as edge cut and counter resets
-- Switches for boolean features such as auto schedule, party mode, ACS, lock and Off Limits
+- Switches for boolean features such as auto schedule, firmware auto update, party mode, ACS, lock and Off Limits
 - Numbers for writable values such as rain delay, cutting height, time extension, torque and lawn metadata
 - Select entities for zone choice and auto-schedule tuning
 - The `landroid_cloud.ots` service for starting a one-time schedule
@@ -190,6 +209,12 @@ Because of that, changes made from Home Assistant do not appear immediately in t
 
 Legacy mowers expose the configured start-point zones for selection.
 RTK/Vision style zone IDs are exposed read-only, and changing the selected RTK zone from Home Assistant is not supported yet.
+
+### Firmware updates
+
+Firmware update metadata is read from the vendor cloud API and merged with the mower's live firmware payload when available.
+
+Because availability and release notes come from cloud lookups instead of the normal push updates, Home Assistant may show new firmware details only after the next refresh or when the update entity explicitly refreshes its metadata.
 
 ### Custom integration services
 

--- a/README.md
+++ b/README.md
@@ -148,14 +148,145 @@ Numbers require the mower to be online and are disabled by default.
 
 ## Actions and control model
 
-The integration exposes control through native entities and one legacy-compatible service:
+The integration exposes control through native entities and custom `lawn_mower` actions:
 
 - Lawn mower actions for start, pause and dock
 - Buttons for one-shot actions such as edge cut and counter resets
 - Switches for boolean features such as ACS, lock and Off Limits
 - Numbers for writable values such as rain delay, cutting height, time extension and torque
 - Select for zone choice
-- The `landroid_cloud.ots` service for starting a one-time schedule with boundary and runtime parameters
+- The `lawn_mower.ots` action for starting a one-time schedule
+- The `lawn_mower.add_schedule`, `lawn_mower.edit_schedule`, and `lawn_mower.delete_schedule` actions for schedule management
+
+### Custom lawn mower actions
+
+All custom actions target a `lawn_mower` entity from this integration.
+
+#### `lawn_mower.ots`
+
+Starts a one-time mowing session on mowers that support it.
+
+Fields:
+
+- `boundary`: Include boundary or edge cutting
+- `runtime`: Run time in minutes, from `10` to `120`
+
+Example:
+
+```yaml
+action: lawn_mower.ots
+target:
+  entity_id: lawn_mower.my_landroid
+data:
+  boundary: false
+  runtime: 45
+```
+
+#### `lawn_mower.add_schedule`
+
+Creates one or more recurring schedule entries in a single action call.
+
+Fields:
+
+- `days`: One or more days of the week
+- `start`: Start time in `HH:MM` format
+- `duration`: Duration in minutes
+- `boundary`: Optional. If omitted, boundary defaults to `false` on mowers that require it
+
+Behavior:
+
+- If you select multiple days, the same schedule is created for each selected day
+- On mowers with two slots per day, the integration automatically chooses the first or second free slot
+- On mowers that support more than two daily entries, the integration will keep adding entries on the selected day as long as the mower accepts them
+
+Example:
+
+```yaml
+action: lawn_mower.add_schedule
+target:
+  entity_id: lawn_mower.my_landroid
+data:
+  days:
+    - monday
+    - wednesday
+    - friday
+  start: "09:00"
+  duration: 60
+  boundary: false
+```
+
+#### `lawn_mower.edit_schedule`
+
+Updates one existing schedule entry.
+
+Fields:
+
+- `current_day`: The current day of the schedule you want to change
+- `current_start`: Optional. Use this when that day has more than one schedule
+- `day`: The new day
+- `start`: The new start time in `HH:MM` format
+- `duration`: The new duration in minutes
+- `boundary`: Optional boundary setting for the updated entry
+
+Behavior:
+
+- If the selected current day only has one schedule, `current_start` is not needed
+- If the day has multiple schedules, you must provide `current_start` so the integration knows which one to edit
+- When moving an entry to a different day, the integration automatically resolves the correct slot behind the scenes
+
+Example:
+
+```yaml
+action: lawn_mower.edit_schedule
+target:
+  entity_id: lawn_mower.my_landroid
+data:
+  current_day: monday
+  current_start: "09:00"
+  day: tuesday
+  start: "10:30"
+  duration: 45
+  boundary: true
+```
+
+#### `lawn_mower.delete_schedule`
+
+Deletes one schedule entry or clears the whole schedule.
+
+Fields:
+
+- `all_schedules`: Optional. Set to `true` to remove every schedule entry in one call
+- `day`: Day of the schedule you want to delete
+- `start`: Optional. Use this when the selected day has more than one schedule
+
+Behavior:
+
+- If `all_schedules` is `true`, all schedule entries are removed and `day` is not needed
+- If a day only has one schedule, `start` is not needed
+- If a day has multiple schedules, you must provide `start`
+
+Examples:
+
+```yaml
+action: lawn_mower.delete_schedule
+target:
+  entity_id: lawn_mower.my_landroid
+data:
+  day: monday
+  start: "09:00"
+```
+
+```yaml
+action: lawn_mower.delete_schedule
+target:
+  entity_id: lawn_mower.my_landroid
+data:
+  all_schedules: true
+```
+
+### Finding the right schedule to edit or delete
+
+Enable the `Next schedule` sensor if you want a simple view of the normalized schedule data the integration uses. Its attributes include `schedule_entries`, which can help you see which days and start times currently exist for the mower.
 
 ## Availability behavior
 

--- a/README.md
+++ b/README.md
@@ -1,39 +1,169 @@
-[![landroid_cloud](https://img.shields.io/github/release/mtrab/landroid_cloud/all.svg?style=plastic&label=Current%20release)](https://github.com/mtrab/landroid_cloud) [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=plastic)](https://github.com/hacs/integration) [![downloads](https://img.shields.io/github/downloads/mtrab/landroid_cloud/total?style=plastic&label=Total%20downloads)](https://github.com/mtrab/landroid_cloud) [![Buy me a coffee](https://img.shields.io/static/v1?label=Buy%20me%20a%20coffee&message=and%20say%20thanks&color=orange&logo=buymeacoffee&logoColor=white&style=plastic)](https://www.buymeacoffee.com/mtrab)
+[![landroid_cloud](https://img.shields.io/github/release/mtrab/landroid_cloud/all.svg?style=plastic&label=Current%20release)](https://github.com/mtrab/landroid_cloud) [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=plastic)](https://github.com/hacs/integration) [![downloads](https://img.shields.io/github/downloads/mtrab/landroid_cloud/total?style=plastic&label=Total%20downloads)](https://github.com/mtrab/landroid_cloud)
+
+<a href="https://www.buymeacoffee.com/mtrab" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
 
 # Landroid Cloud
 
-This component has been created to be used with Home Assistant.
+This integration is designed for Home Assistant.
 
-Landroid Cloud presents a possibility to connect your Landroid Cloud compatible mowers to Home Assistant.<br />
-Currently these vendors are supported:<br />
+Landroid Cloud lets you connect your cloud-compatible mower to Home Assistant.
+
+### Currently these vendors are supported:
+
 - Worx Landroid
 - Kress
 - LandXcape
 
-### Installation:
+## Installation
 
-#### HACS
+### HACS
 
 - Ensure that HACS is installed.
-- Search for and install the "Landroid Cloud" integration.
+- Search for and install the `Landroid Cloud` integration (or click the blue button below to go there directly).
 - Restart Home Assistant.
 - Go to Integrations and add the Landroid Cloud integration
 
-#### Manual installation
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=MTrab&repository=landroid_cloud)
+
+### Manual installation
 
 - Download the latest release.
 - Unpack the release and copy the custom_components/landroid_cloud directory into the custom_components directory of your Home Assistant installation.
 - Restart Home Assistant.
 - Go to Integrations and add the Landroid Cloud integration
 
-### Landroid Card
+## Setup
+
+Open the integration setup directly:
+
+[![](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=landroid_cloud)
+
+Or go to `Home Assistant` > `Settings` > `Devices & services`
+
+Add the `Landroid Cloud` integration _(If it doesn't show, try CTRL+F5 to force a refresh of the page)_
+
+Use the same credentials as in your mower app.
+
+## Landroid Card
 
 [Barma-lej](https://github.com/barma-lej) has created a custom card for the Landroid Cloud integration.<br/>
 You can find installation instructions on [this Github repo](https://github.com/Barma-lej/landroid-card)
 
 
-### Other useful information
-#### Services and app stopped working
+## Integration overview
+
+The integration exposes each mower as a Home Assistant device with a native lawn mower entity and a set of related entities for telemetry, diagnostics and configuration.
+
+Write-capable entities become unavailable while the mower is offline. Read-only entities remain available so status and diagnostics can still be inspected.
+
+### Supported vendors
+
+- Worx Landroid
+- Kress
+- LandXcape
+
+### Exposed entities
+
+#### Lawn mower
+
+Each mower creates one lawn mower entity with these actions:
+
+- Start mowing
+- Pause
+- Return to dock
+
+#### Sensors
+
+| Entity | Category | Default |
+| --- | --- | --- |
+| Battery | Standard | Enabled |
+| Status | Standard | Enabled |
+| Error | Diagnostic | Enabled |
+| Signal strength | Diagnostic | Disabled |
+| Daily progress | Standard | Disabled |
+| Next schedule | Standard | Disabled |
+| Rain delay remaining | Standard | Disabled |
+| Battery charge cycles total | Diagnostic | Disabled |
+| Battery charge cycles since reset | Diagnostic | Disabled |
+| Battery temperature | Diagnostic | Disabled |
+| Battery voltage | Diagnostic | Disabled |
+| Blade runtime total | Diagnostic | Disabled |
+| Blade runtime since reset | Diagnostic | Disabled |
+| Distance driven total | Diagnostic | Disabled |
+| Mower runtime total | Diagnostic | Disabled |
+
+Notes:
+
+- `Next schedule` is exposed as a timestamp sensor and includes known schedule details as attributes.
+- Duration and distance sensors suggest user-friendly display units where Home Assistant supports conversion.
+
+#### Binary sensors
+
+| Entity | Category | Default |
+| --- | --- | --- |
+| Charging | Diagnostic | Enabled |
+| Rain sensor | Diagnostic | Disabled |
+
+#### Switches
+
+All switches are configuration entities and require the mower to be online.
+
+| Entity | Default | Notes |
+| --- | --- | --- |
+| Party mode | Disabled | Requires party mode support |
+| Lock | Disabled | |
+| Off Limits | Enabled | Requires Off Limits support |
+| Off Limits shortcuts | Enabled | Requires Off Limits support |
+| ACS | Enabled | Requires ACS support |
+
+#### Buttons
+
+Buttons require the mower to be online.
+
+| Entity | Category | Default | Notes |
+| --- | --- | --- | --- |
+| Edge cut | Standard | Disabled | Requires edge cut support |
+| Reset blade runtime | Configuration | Disabled | |
+| Reset battery cycles | Configuration | Disabled | |
+
+#### Numbers
+
+Numbers require the mower to be online and are disabled by default.
+
+| Entity | Category | Range | Step | Notes |
+| --- | --- | --- | --- | --- |
+| Rain delay | Configuration | 0-300 min | 1 | |
+| Cutting height | Configuration | 20-70 mm | 1 | Requires cutting height support |
+| Time extension | Configuration | -100% to 100% | 10 | |
+
+#### Selects
+
+| Entity | Category | Default | Notes |
+| --- | --- | --- | --- |
+| Zone | Configuration | Disabled | Requires mower to be online |
+
+## Actions and control model
+
+The integration does not add custom Home Assistant services. Control is exposed through native entities instead:
+
+- Lawn mower actions for start, pause and dock
+- Buttons for one-shot actions such as edge cut and counter resets
+- Switches for boolean features such as ACS, lock and Off Limits
+- Numbers for writable values such as rain delay, cutting height and time extension
+- Select for zone choice
+
+## Availability behavior
+
+- Read-only entities stay available when the mower is offline
+- Write-capable entities are marked unavailable when the mower is offline
+- If coordinator data itself is unavailable, all related entities become unavailable
+
+## Diagnostics and issue reporting
+
+If you open an issue, include a Home Assistant diagnostics download whenever possible. Diagnostics are much more useful than pasted JSON fragments or screenshots of attributes.
+
+## Other useful information
+### Services and app stopped working
 
 You might experience being banned from Worx Landroid Cloud service.
 Follow this simple guide to make it work again:
@@ -41,7 +171,3 @@ Follow this simple guide to make it work again:
 * Unlink your Landroid(s)
 * Open app on mobile device
 * Add Landroid(s)
-
-### To-do
-
-* Make this an official integration (far in the future as there is to many changes right now)

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ All switches are configuration entities and require the mower to be online.
 
 | Entity | Default | Notes |
 | --- | --- | --- |
-| Party mode | Disabled | Requires party mode support |
+| Pause mode | Disabled | Requires pause mode support |
 | Lock | Disabled | |
 | Off Limits | Enabled | Requires Off Limits support |
 | Off Limits shortcuts | Enabled | Requires Off Limits support |


### PR DESCRIPTION
## Summary
Refresh the README so it documents the current integration behavior, exposed entities, actions, availability rules and diagnostics guidance while keeping the existing badges, installation sections and Landroid Card section intact.

## Testing
- Documentation only; no code changes.

## Known limitations
- The README reflects the current entity model and may need future updates as new entities are added.
