### PR TITLE
Automate release manifest updates and asset publishing

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -1,4 +1,4 @@
-name: Code validation
+name: HACS validation
 
 on:
   push:

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,4 +1,4 @@
-name: Code validation
+name: Hassfest validation
 
 on:
   push:

--- a/.github/workflows/release-manifest-automerge.yml
+++ b/.github/workflows/release-manifest-automerge.yml
@@ -1,0 +1,154 @@
+name: Release Manifest Automerge
+
+on:
+  workflow_run:
+    workflows:
+      - HACS validation
+      - Hassfest validation
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-manifest-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  merge_and_upload_release_asset:
+    name: Merge release manifest PR and upload asset
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          pr_json="$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "${{ github.repository_owner }}:$HEAD_BRANCH" \
+            --state open \
+            --json number,body,mergeStateStatus)"
+
+          if [ "$(printf '%s' "$pr_json" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')" -eq 0 ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          printf '%s' "$pr_json" | python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import re
+          import sys
+
+          pr = json.load(sys.stdin)[0]
+          match = re.search(r"release-tag:\s*(\S+)", pr.get("body") or "")
+
+          print("found=true")
+          print(f"number={pr['number']}")
+          print(f"merge_state={pr['mergeStateStatus']}")
+          print(f"release_tag={match.group(1) if match else ''}")
+          PY
+
+      - name: Verify required checks are complete
+        if: steps.pr.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          checks_json="$(gh api \
+            "repos/${{ github.repository }}/commits/${HEAD_SHA}/check-runs")"
+
+          printf '%s' "$checks_json" | python3 - <<'PY'
+          import json
+          import sys
+
+          payload = json.load(sys.stdin)
+          required = {
+              "HACS validation": "success",
+              "Hassfest validation": "success",
+          }
+
+          results = {run["name"]: run["conclusion"] for run in payload["check_runs"]}
+          missing = [
+              name for name, conclusion in required.items()
+              if results.get(name) != conclusion
+          ]
+
+          if missing:
+              raise SystemExit(
+                  f"Required checks not ready for merge: {', '.join(missing)}"
+              )
+          PY
+
+      - name: Merge pull request
+        if: steps.pr.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          for _ in 1 2 3 4 5 6; do
+            merge_state="$(gh pr view "$PR_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --json mergeStateStatus \
+              --jq '.mergeStateStatus')"
+
+            if [ "$merge_state" = "CLEAN" ] || [ "$merge_state" = "HAS_HOOKS" ] || [ "$merge_state" = "UNSTABLE" ]; then
+              break
+            fi
+
+            sleep 10
+          done
+
+          gh pr merge "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --merge \
+            --delete-branch
+
+      - name: Resolve merge commit
+        if: steps.pr.outputs.found == 'true'
+        id: merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          merge_sha="$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json mergeCommit \
+            --jq '.mergeCommit.oid')"
+          echo "sha=${merge_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Check out merge commit
+        if: steps.pr.outputs.found == 'true'
+        env:
+          MERGE_SHA: ${{ steps.merge.outputs.sha }}
+        run: |
+          git fetch origin master --depth=1
+          git checkout "$MERGE_SHA"
+
+      - name: Create zip
+        if: steps.pr.outputs.found == 'true'
+        run: |
+          cd custom_components/landroid_cloud
+          zip landroid_cloud.zip -r ./
+
+      - name: Upload zip to release
+        if: steps.pr.outputs.found == 'true'
+        uses: svenstaro/upload-release-action@2.11.4
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./custom_components/landroid_cloud/landroid_cloud.zip
+          asset_name: landroid_cloud.zip
+          tag: refs/tags/${{ steps.pr.outputs.release_tag }}
+          overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,31 +5,102 @@ on:
   release:
     types: [published]
 
-env:
-  COMPONENT_DIR: landroid_cloud
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  release_zip_file:
-    name: Prepare release asset
+  prepare_release_manifest:
+    name: Prepare release manifest PR
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Derive release metadata
+        id: metadata
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os
+
+          release_tag = os.environ["RELEASE_TAG"]
+          normalized = release_tag[1:] if release_tag.startswith("v") else release_tag
+          branch_name = f"release/{release_tag}"
+
+          print(f"normalized_version={normalized}")
+          print(f"branch_name={branch_name}")
+          PY
+
       - name: Update manifest.json version to ${{ github.event.release.tag_name }}
         run: |
-          python3 ${{ github.workspace }}/.github/scripts/update_hacs_manifest.py --version ${{ github.event.release.tag_name }} --path /custom_components/landroid_cloud/
-      - name: Commit manifest update
+          python3 "${{ github.workspace }}/.github/scripts/update_hacs_manifest.py" \
+            --version "${{ github.event.release.tag_name }}" \
+            --path /custom_components/landroid_cloud/
+
+      - name: Check whether manifest changed
+        id: manifest
+        run: |
+          if git diff --quiet -- custom_components/landroid_cloud/manifest.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release manifest branch and PR
+        if: steps.manifest.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_BRANCH: ${{ steps.metadata.outputs.branch_name }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add ./custom_components/landroid_cloud/manifest.json
-          git commit -m "Updated manifest.json"
-          git push origin HEAD:master
-      - name: Create zip
+          git checkout -B "$RELEASE_BRANCH"
+          git add custom_components/landroid_cloud/manifest.json
+          git commit -m "chore: bump manifest for ${RELEASE_TAG}"
+          git push --force-with-lease --set-upstream origin "$RELEASE_BRANCH"
+
+          existing_pr="$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "${{ github.repository_owner }}:$RELEASE_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number')"
+
+          if [ -n "$existing_pr" ]; then
+            gh pr edit "$existing_pr" \
+              --repo "${{ github.repository }}" \
+              --add-label skip-changelog \
+              --title "chore: bump manifest for ${RELEASE_TAG} release" \
+              --body "Automated manifest version bump for ${RELEASE_TAG}.
+
+          release-tag: ${RELEASE_TAG}"
+            exit 0
+          fi
+
+          gh pr create \
+            --repo "${{ github.repository }}" \
+            --base master \
+            --head "$RELEASE_BRANCH" \
+            --title "chore: bump manifest for ${RELEASE_TAG} release" \
+            --body "Automated manifest version bump for ${RELEASE_TAG}.
+
+          release-tag: ${RELEASE_TAG}" \
+            --label skip-changelog
+
+      - name: Create zip immediately when manifest is already up to date
+        if: steps.manifest.outputs.changed == 'false'
         run: |
           cd custom_components/landroid_cloud
           zip landroid_cloud.zip -r ./
-      - name: Upload zip to release
+
+      - name: Upload zip immediately when manifest is already up to date
+        if: steps.manifest.outputs.changed == 'false'
         uses: svenstaro/upload-release-action@2.11.4
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- automate release-time manifest bumps by creating a `release/<tag>` branch and PR
- auto-merge the release PR after `HACS validation` and `Hassfest validation` pass
- build and upload the release ZIP from the merged commit
- split the HACS and Hassfest workflow names so `workflow_run` can target them explicitly

## Test strategy
- validated the updated workflow YAML files with `yaml.safe_load` locally
- verified the repository branch protection and required check names via GitHub API
- not yet validated end-to-end in GitHub Actions

## Known limitations
- the new release flow still needs one real GitHub release run to verify branch creation, PR merge timing, and ZIP upload behavior
- if GitHub delays PR mergeability recalculation after checks complete, the automerge workflow relies on a short retry loop before merging

## Configuration changes
- workflow names now expose `HACS validation` and `Hassfest validation` explicitly instead of sharing `Code validation`