### PR TITLE
Remove release-time validation steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,14 +74,6 @@ jobs:
               manifest_file.write("\\n")
           PY
 
-      - name: Run HACS validation
-        uses: hacs/action@main
-        with:
-          category: integration
-
-      - name: Run Hassfest validation
-        uses: home-assistant/actions/hassfest@master
-
       - name: Commit manifest update
         id: commit
         run: |


### PR DESCRIPTION
## Summary
- remove the HACS and Hassfest steps from the release workflow
- let the publish flow go directly from manifest bump to commit, tag, ZIP generation, and asset upload

## Why
The new release pipeline now authenticates correctly with the GitHub App, but it is currently blocked by release-time Hassfest failures. This change makes the release workflow behave as requested: publish the release and update the repository automatically without gating on those validations.

## Test strategy
- reproduced the current failure on release run `23046329317`
- validated `.github/workflows/release.yml` with `yaml.safe_load` after removing the validation steps

## Known limitations
- release-time validation is no longer performed in this workflow
- normal repository validation workflows still exist outside the release pipeline

## Configuration changes
- none beyond the existing GitHub App setup

## Labels
- intended label: `skip-changelog`