### PR TITLE
Fix manifest newline handling in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
 
           with manifest_path.open("w", encoding="utf-8") as manifest_file:
               json.dump(ordered_manifest, manifest_file, indent=4)
-              manifest_file.write("\\n")
+              manifest_file.write("\n")
           PY
 
       - name: Commit manifest update

--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -16,4 +16,4 @@
         "pyworxcloud==6.0.4"
     ],
     "version": "7.0.0b1"
-}\n
+}


### PR DESCRIPTION
## Summary
- fix the release workflow so it writes a real newline to `manifest.json` instead of the literal `\n` characters
- repair the currently committed `manifest.json` so HACS and Hassfest can parse it again

## Test strategy
- ran `python3 -m json.tool custom_components/landroid_cloud/manifest.json`
- verified the file ending bytes to confirm the manifest now ends with a normal newline

## Known limitations
- this does not retroactively fix already-published release artifacts

## Configuration changes
- none
