### PR TITLE
Tone down issue auto labels for feature requests

### DIFF
--- a/.github/workflows/issue-auto-labels.yml
+++ b/.github/workflows/issue-auto-labels.yml
@@ -64,9 +64,10 @@ jobs:
             const existingLabels = (context.payload.issue.labels ?? []).map(
               (label) => label.name,
             );
+            const isFeatureRequest = existingLabels.includes(featureRequestLabel);
 
             if (
-              existingLabels.includes(featureRequestLabel) &&
+              isFeatureRequest &&
               !context.payload.issue.title.startsWith(featureRequestPrefix)
             ) {
               await github.rest.issues.update({
@@ -92,7 +93,7 @@ jobs:
               !hasMeaningfulValue(diagnosticsFile) &&
               !hasMeaningfulValue(diagnosticsExplanation);
 
-            if (diagnosticsMissing) {
+            if (!isFeatureRequest && diagnosticsMissing) {
               labels.add(diagnosticsMissingLabel);
 
               try {


### PR DESCRIPTION
## Summary
- skip diagnostics-missing handling for issues labeled as feature requests
- keep the existing feature request title prefix behavior intact

## Test strategy
- reviewed the workflow diff for the GitHub Script logic change
- verified the diagnostics branch now only runs when `feature request` is not present

## Known limitations
- not exercised in a live GitHub Actions run yet

## Configuration changes
- none