### PR TITLE
Bump pyworxcloud to 6.1.0

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -13,7 +13,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud@git+https://github.com/MTrab/pyworxcloud.git@master"
+        "pyworxcloud==6.1.0"
     ],
     "version": "7.0.0b1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytest-asyncio==1.3.0
 pytest-cov==7.0.0
 pip>=21.0,<26.1
 ruff==0.15.6
-pyworxcloud==6.0.5
+pyworxcloud==6.1.0


### PR DESCRIPTION
## Summary
Updates the integration dependency pins to `pyworxcloud==6.1.0` in both the Home Assistant manifest and local development requirements.

## Test strategy
Validated the manifest JSON locally. No additional local test suite was run for this dependency bump.

## Known limitations
Dependency availability may lag briefly across package mirrors, but the target release has been published.

## Required configuration changes
None.

## Semver
Proposed label: patch (explicitly requested).