### PR TITLE
Let old v6 config entries move into v7 on their own

### DIFF
--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.loader import async_get_integration
@@ -25,8 +26,10 @@ from pyworxcloud.exceptions import (
 
 from .awsiot import async_prime_awsiot_metrics
 from .const import (
+    CloudProvider,
     CONF_CLOUD,
     CONF_COMMAND_TIMEOUT,
+    DEFAULT_CLOUD,
     DEFAULT_COMMAND_TIMEOUT,
     DOMAIN,
     PLATFORMS,
@@ -37,6 +40,106 @@ from .models import LandroidRuntimeData
 
 type LandroidConfigEntry = ConfigEntry[LandroidRuntimeData]
 _LOGGER = logging.getLogger(__name__)
+_CONFIG_ENTRY_VERSION = 2
+_SUPPORTED_CLOUDS = {provider.value for provider in CloudProvider}
+
+
+def _normalize_cloud_provider(value: Any | None) -> str:
+    """Return a canonical cloud provider value."""
+    if isinstance(value, str):
+        cloud = value.lower()
+        if cloud in _SUPPORTED_CLOUDS:
+            return cloud
+
+    return DEFAULT_CLOUD
+
+
+def _entry_cloud_provider(entry: ConfigEntry[Any]) -> str:
+    """Resolve the configured cloud provider from current or legacy data."""
+    return _normalize_cloud_provider(
+        entry.data.get(CONF_CLOUD) or entry.data.get(CONF_TYPE)
+    )
+
+
+def _target_unique_id(email: str, cloud: str) -> str:
+    """Return the canonical v7 unique id."""
+    return f"{email.lower()}::{cloud}"
+
+
+def _legacy_unique_id_candidates(
+    email: str, cloud: str, legacy_cloud: str | None
+) -> set[str]:
+    """Return known v6 unique id candidates for an entry."""
+    candidates = {
+        f"{email}_{cloud}",
+        f"{email.lower()}_{cloud.lower()}",
+    }
+    if legacy_cloud is not None:
+        candidates.update(
+            {
+                f"{email}_{legacy_cloud}",
+                f"{email.lower()}_{legacy_cloud.lower()}",
+            }
+        )
+
+    return candidates
+
+
+def _unique_id_conflicts(
+    hass: HomeAssistant, entry: ConfigEntry[Any], unique_id: str
+) -> bool:
+    """Return whether another config entry already uses the target unique id."""
+    for other_entry in hass.config_entries.async_entries(DOMAIN):
+        if other_entry.entry_id != entry.entry_id and other_entry.unique_id == unique_id:
+            return True
+
+    return False
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry[Any]) -> bool:
+    """Migrate an older config entry to the v7 schema."""
+    if entry.version >= _CONFIG_ENTRY_VERSION:
+        return True
+
+    original_data = dict(entry.data)
+    migrated_data = dict(original_data)
+    cloud = _entry_cloud_provider(entry)
+
+    if migrated_data.get(CONF_CLOUD) != cloud:
+        migrated_data[CONF_CLOUD] = cloud
+
+    migrated_data.pop(CONF_TYPE, None)
+
+    update_kwargs: dict[str, Any] = {
+        "data": migrated_data,
+        "version": _CONFIG_ENTRY_VERSION,
+    }
+
+    email = migrated_data.get(CONF_EMAIL)
+    if isinstance(email, str) and email:
+        target_unique_id = _target_unique_id(email, cloud)
+        current_unique_id = entry.unique_id
+        legacy_cloud = original_data.get(CONF_TYPE)
+        legacy_candidates = {
+            candidate.casefold()
+            for candidate in _legacy_unique_id_candidates(
+                email, cloud, legacy_cloud if isinstance(legacy_cloud, str) else None
+            )
+        }
+
+        if current_unique_id != target_unique_id:
+            if current_unique_id is None or current_unique_id.casefold() in legacy_candidates:
+                if _unique_id_conflicts(hass, entry, target_unique_id):
+                    _LOGGER.warning(
+                        "Skipping unique_id migration for entry %s because %s is already in use",
+                        entry.entry_id,
+                        target_unique_id,
+                    )
+                else:
+                    update_kwargs["unique_id"] = target_unique_id
+
+    hass.config_entries.async_update_entry(entry, **update_kwargs)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: LandroidConfigEntry) -> bool:
@@ -44,10 +147,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: LandroidConfigEntry) -> 
     integration = await async_get_integration(hass, DOMAIN)
     _LOGGER.info(STARTUP, integration.version)
 
+    cloud_type = _entry_cloud_provider(entry)
     cloud = WorxCloud(
         entry.data[CONF_EMAIL],
         entry.data[CONF_PASSWORD],
-        entry.data[CONF_CLOUD],
+        cloud_type,
         tz=hass.config.time_zone,
         command_timeout=entry.options.get(
             CONF_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT

--- a/custom_components/landroid_cloud/config_flow.py
+++ b/custom_components/landroid_cloud/config_flow.py
@@ -73,7 +73,7 @@ async def _validate_input(user_input: dict[str, Any]) -> dict[str, Any]:
 class LandroidCloudConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Landroid Cloud."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -1,0 +1,248 @@
+"""Tests for v6 to v7 config migration behavior."""
+
+from __future__ import annotations
+
+from types import MappingProxyType, SimpleNamespace
+
+import pytest
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+
+from custom_components.landroid_cloud import async_migrate_entry, async_setup_entry
+from custom_components.landroid_cloud.const import CONF_CLOUD, DEFAULT_CLOUD, DOMAIN
+
+
+def _make_config_entry(
+    *,
+    entry_id: str,
+    data: dict[str, object],
+    unique_id: str | None,
+    version: int = 1,
+) -> ConfigEntry:
+    """Build a lightweight config entry for migration tests."""
+    return ConfigEntry(
+        version=version,
+        minor_version=0,
+        domain=DOMAIN,
+        title="Landroid Cloud",
+        data=data,
+        source="user",
+        unique_id=unique_id,
+        options={},
+        subentries_data=(),
+        discovery_keys=MappingProxyType({}),
+        entry_id=entry_id,
+        state=ConfigEntryState.NOT_LOADED,
+    )
+
+
+class _ConfigEntriesManager:
+    """Capture config entry updates during migration."""
+
+    def __init__(self, entries: list[ConfigEntry]) -> None:
+        self._entries = entries
+        self.updates: list[dict[str, object]] = []
+
+    def async_entries(self, domain: str) -> list[ConfigEntry]:
+        """Return entries for the requested domain."""
+        return [entry for entry in self._entries if entry.domain == domain]
+
+    def async_update_entry(self, entry: ConfigEntry, **kwargs) -> bool:
+        """Apply updates in the same shape Home Assistant would."""
+        self.updates.append(kwargs)
+        if "data" in kwargs:
+            object.__setattr__(entry, "data", MappingProxyType(dict(kwargs["data"])))
+        if "unique_id" in kwargs:
+            object.__setattr__(entry, "unique_id", kwargs["unique_id"])
+        if "version" in kwargs:
+            object.__setattr__(entry, "version", kwargs["version"])
+        if "title" in kwargs:
+            object.__setattr__(entry, "title", kwargs["title"])
+        return True
+
+
+@pytest.mark.asyncio
+async def test_async_migrate_entry_moves_legacy_type_to_cloud_and_unique_id() -> None:
+    """Old v6 entries should be migrated to the v7 data and unique id format."""
+    entry = _make_config_entry(
+        entry_id="entry-1",
+        data={
+            "email": "User@Example.com",
+            "password": "secret",
+            "type": "Worx",
+        },
+        unique_id="User@Example.com_Worx",
+    )
+    manager = _ConfigEntriesManager([entry])
+    hass = SimpleNamespace(config_entries=manager)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert dict(entry.data) == {
+        "email": "User@Example.com",
+        "password": "secret",
+        CONF_CLOUD: DEFAULT_CLOUD,
+    }
+    assert entry.unique_id == "user@example.com::worx"
+    assert entry.version == 2
+    assert manager.updates == [
+        {
+            "data": {
+                "email": "User@Example.com",
+                "password": "secret",
+                CONF_CLOUD: DEFAULT_CLOUD,
+            },
+            "version": 2,
+            "unique_id": "user@example.com::worx",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_migrate_entry_defaults_cloud_and_skips_unique_id_conflict() -> None:
+    """Migration should fall back to Worx and avoid unique id clashes."""
+    entry = _make_config_entry(
+        entry_id="entry-1",
+        data={
+            "email": "user@example.com",
+            "password": "secret",
+        },
+        unique_id=None,
+    )
+    conflicting_entry = _make_config_entry(
+        entry_id="entry-2",
+        data={
+            "email": "other@example.com",
+            "password": "secret",
+            CONF_CLOUD: "worx",
+        },
+        unique_id="user@example.com::worx",
+        version=2,
+    )
+    manager = _ConfigEntriesManager([entry, conflicting_entry])
+    hass = SimpleNamespace(config_entries=manager)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert dict(entry.data) == {
+        "email": "user@example.com",
+        "password": "secret",
+        CONF_CLOUD: DEFAULT_CLOUD,
+    }
+    assert entry.unique_id is None
+    assert entry.version == 2
+    assert manager.updates == [
+        {
+            "data": {
+                "email": "user@example.com",
+                "password": "secret",
+                CONF_CLOUD: DEFAULT_CLOUD,
+            },
+            "version": 2,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_falls_back_to_legacy_type_field(monkeypatch) -> None:
+    """Setup should continue to work when only the legacy type field exists."""
+    captured: dict[str, object] = {}
+
+    class FakeCloud:
+        """Minimal WorxCloud stub for setup verification."""
+
+        def __init__(
+            self,
+            email: str,
+            password: str,
+            cloud: str,
+            *,
+            tz: str,
+            command_timeout: float,
+        ) -> None:
+            captured.update(
+                {
+                    "email": email,
+                    "password": password,
+                    "cloud": cloud,
+                    "tz": tz,
+                    "command_timeout": command_timeout,
+                }
+            )
+            self.devices = {}
+
+        async def authenticate(self) -> bool:
+            return True
+
+        async def connect(self) -> bool:
+            return True
+
+        async def disconnect(self) -> None:
+            return None
+
+    class FakeCoordinator:
+        """Avoid touching the real coordinator in the setup test."""
+
+        def __init__(self, hass, cloud) -> None:
+            self.hass = hass
+            self.cloud = cloud
+            self.data = {}
+
+        async def async_setup(self) -> None:
+            return None
+
+        async def async_config_entry_first_refresh(self) -> None:
+            return None
+
+        async def async_shutdown(self) -> None:
+            return None
+
+    async def _async_get_integration(_hass, _domain):
+        return SimpleNamespace(version="7.0.0b1")
+
+    async def _async_forward_entry_setups(_entry, _platforms):
+        return True
+
+    async def _async_prime_awsiot_metrics() -> None:
+        return None
+
+    entry = SimpleNamespace(
+        data={
+            "email": "user@example.com",
+            "password": "secret",
+            "type": "Kress",
+        },
+        options={},
+        entry_id="entry-1",
+        runtime_data=None,
+        add_update_listener=lambda _callback: None,
+        async_on_unload=lambda _callback: None,
+    )
+    hass = SimpleNamespace(
+        config=SimpleNamespace(time_zone="UTC"),
+        config_entries=SimpleNamespace(
+            async_forward_entry_setups=_async_forward_entry_setups,
+        ),
+    )
+
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.async_get_integration",
+        _async_get_integration,
+    )
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.async_prime_awsiot_metrics",
+        _async_prime_awsiot_metrics,
+    )
+    monkeypatch.setattr("custom_components.landroid_cloud.WorxCloud", FakeCloud)
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.LandroidCloudCoordinator",
+        FakeCoordinator,
+    )
+
+    assert await async_setup_entry(hass, entry) is True
+    assert captured == {
+        "email": "user@example.com",
+        "password": "secret",
+        "cloud": "kress",
+        "tz": "UTC",
+        "command_timeout": 30.0,
+    }
+    assert entry.runtime_data.cloud is not None
+    assert entry.runtime_data.coordinator.cloud is entry.runtime_data.cloud


### PR DESCRIPTION
This PR is about making the v6 to v7 upgrade feel uneventful for existing users.

In v6 the integration stored the provider in `type`, while v7 expects `cloud`. That made some old config entries fall over during setup, and it also meant older unique IDs no longer matched the new format.

This change migrates old entries forward automatically, keeps setup tolerant during the transition, and updates legacy unique IDs when it can do so safely. If a new unique ID would clash with an existing entry, it keeps the old one and logs a warning instead of breaking the install.

## How I tested it
- `PYTHONPATH=/workspaces/pyworxcloud pytest -q tests/test_config_flow.py tests/test_config_migration.py`
- `ruff check custom_components/landroid_cloud/__init__.py custom_components/landroid_cloud/config_flow.py tests/test_config_flow.py tests/test_config_migration.py`

## Known limitation
If a legacy unique ID collides with one that is already in use, the entry keeps its old unique ID. That is deliberate so we do not block startup.

## Config impact
Existing v6 entries should migrate automatically. No manual re-add should be needed in the normal Worx case.
