### PR TITLE
Disable ACS by default

### DIFF
--- a/custom_components/landroid_cloud/switch.py
+++ b/custom_components/landroid_cloud/switch.py
@@ -57,6 +57,7 @@ SWITCHES: tuple[LandroidSwitchDescription, ...] = (
         translation_key="acs",
         icon="mdi:radar",
         entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
         capability=DeviceCapability.ACS,
     ),
 )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -20,3 +20,10 @@ def test_pause_mode_is_disabled_by_default() -> None:
     )
 
     assert pause_mode.entity_registry_enabled_default is False
+
+
+def test_acs_is_disabled_by_default() -> None:
+    """ACS should be disabled by default."""
+    acs = next(description for description in SWITCHES if description.key == "acs")
+
+    assert acs.entity_registry_enabled_default is False


### PR DESCRIPTION
This is a small quality-of-life tweak for new installs.

The ACS switch is a configuration-style control, and in practice it is usually better if it does not show up enabled by default in the entity registry. This makes it behave more like the other opt-in config entities we already keep tucked away unless someone actively wants them.

## How I tested it
- `pytest -q tests/test_switch.py`
- `ruff check custom_components/landroid_cloud/switch.py tests/test_switch.py`

## Config impact
No user config changes are needed. Existing entities keep their current registry state. This only changes the default for newly created ACS switch entities.
