### PR TITLE
Fix the format workflow after the migration merge

### DIFF
--- a/custom_components/landroid_cloud/__init__.py
+++ b/custom_components/landroid_cloud/__init__.py
@@ -38,7 +38,7 @@ from .const import (
 from .coordinator import LandroidCloudCoordinator
 from .models import LandroidRuntimeData
 
-type LandroidConfigEntry = ConfigEntry[LandroidRuntimeData]
+LandroidConfigEntry = ConfigEntry[LandroidRuntimeData]
 _LOGGER = logging.getLogger(__name__)
 _CONFIG_ENTRY_VERSION = 2
 _SUPPORTED_CLOUDS = {provider.value for provider in CloudProvider}
@@ -90,7 +90,10 @@ def _unique_id_conflicts(
 ) -> bool:
     """Return whether another config entry already uses the target unique id."""
     for other_entry in hass.config_entries.async_entries(DOMAIN):
-        if other_entry.entry_id != entry.entry_id and other_entry.unique_id == unique_id:
+        if (
+            other_entry.entry_id != entry.entry_id
+            and other_entry.unique_id == unique_id
+        ):
             return True
 
     return False
@@ -128,7 +131,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry[Any]) -> b
         }
 
         if current_unique_id != target_unique_id:
-            if current_unique_id is None or current_unique_id.casefold() in legacy_candidates:
+            if (
+                current_unique_id is None
+                or current_unique_id.casefold() in legacy_candidates
+            ):
                 if _unique_id_conflicts(hass, entry, target_unique_id):
                     _LOGGER.warning(
                         "Skipping unique_id migration for entry %s because %s is already in use",


### PR DESCRIPTION
This is a small follow-up to fix the red `Format code` run on `master` after the config migration merge.

The migration added the newer `type ... = ...` alias syntax in `__init__.py`. That is fine for newer Python versions, but the formatting workflow is still parsing files with Python 3.11, so it choked on that line before it could finish the job.

This keeps the same type alias, but expresses it in a Python 3.11-compatible form so the workflow can parse and format the file again.

## How I tested it
- `python3.11 -m py_compile custom_components/landroid_cloud/__init__.py`
- `ruff format custom_components/landroid_cloud/__init__.py`
- `ruff format --check custom_components/landroid_cloud/__init__.py`
- `ruff check custom_components/landroid_cloud/__init__.py`

## Config impact
No user-facing config changes.
