### PR TITLE
Bring back mower device automations in v7

### DIFF
--- a/custom_components/landroid_cloud/device_action.py
+++ b/custom_components/landroid_cloud/device_action.py
@@ -1,0 +1,96 @@
+"""Provides device actions for Landroid Cloud devices."""
+
+from __future__ import annotations
+
+from typing import Final
+
+import voluptuous as vol
+from homeassistant.components.device_automation import async_validate_entity_schema
+from homeassistant.components.lawn_mower import LawnMowerEntityFeature
+from homeassistant.components.lawn_mower.const import (
+    SERVICE_DOCK,
+    SERVICE_PAUSE,
+    SERVICE_START_MOWING,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_TYPE,
+)
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.entity import get_supported_features
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+
+from . import DOMAIN
+
+MOWER_DOMAIN: Final = "lawn_mower"
+ACTION_TO_SERVICE: Final[dict[str, str]] = {
+    "start_mowing": SERVICE_START_MOWING,
+    "pause": SERVICE_PAUSE,
+    "dock": SERVICE_DOCK,
+}
+ACTION_TO_FEATURE: Final[dict[str, LawnMowerEntityFeature]] = {
+    "start_mowing": LawnMowerEntityFeature.START_MOWING,
+    "pause": LawnMowerEntityFeature.PAUSE,
+    "dock": LawnMowerEntityFeature.DOCK,
+}
+
+_ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(ACTION_TO_SERVICE),
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
+    }
+)
+
+
+async def async_validate_action_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate device action config."""
+    return async_validate_entity_schema(hass, config, _ACTION_SCHEMA)
+
+
+async def async_get_actions(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List available device actions for mower entities."""
+    registry = er.async_get(hass)
+    actions: list[dict[str, str]] = []
+
+    for entry in er.async_entries_for_device(registry, device_id):
+        if entry.domain != MOWER_DOMAIN or entry.platform != DOMAIN:
+            continue
+
+        supported_features = get_supported_features(hass, entry.entity_id)
+        base_action = {
+            CONF_DEVICE_ID: device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: entry.id,
+        }
+
+        for action_type, feature in ACTION_TO_FEATURE.items():
+            if supported_features & feature:
+                actions.append({**base_action, CONF_TYPE: action_type})
+
+    return actions
+
+
+async def async_call_action_from_config(
+    hass: HomeAssistant,
+    config: ConfigType,
+    variables: TemplateVarsType,
+    context: Context | None,
+) -> None:
+    """Execute a configured device action."""
+    del variables
+
+    await hass.services.async_call(
+        MOWER_DOMAIN,
+        ACTION_TO_SERVICE[config[CONF_TYPE]],
+        {ATTR_ENTITY_ID: config[CONF_ENTITY_ID]},
+        blocking=True,
+        context=context,
+    )

--- a/custom_components/landroid_cloud/device_condition.py
+++ b/custom_components/landroid_cloud/device_condition.py
@@ -1,0 +1,87 @@
+"""Provides device conditions for Landroid Cloud devices."""
+
+from __future__ import annotations
+
+from typing import Final
+
+import voluptuous as vol
+from homeassistant.components.lawn_mower import LawnMowerActivity
+from homeassistant.const import (
+    CONF_CONDITION,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_TYPE,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import (
+    condition,
+    config_validation as cv,
+    entity_registry as er,
+)
+from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+
+from . import DOMAIN
+
+MOWER_DOMAIN: Final = "lawn_mower"
+CONDITION_STATE_MAP: Final[dict[str, tuple[str, ...]]] = {
+    "is_mowing": (LawnMowerActivity.MOWING,),
+    "is_docked": (LawnMowerActivity.DOCKED,),
+    "has_error": (LawnMowerActivity.ERROR,),
+    "is_returning": (LawnMowerActivity.RETURNING,),
+}
+
+CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
+        vol.Required(CONF_TYPE): vol.In(CONDITION_STATE_MAP),
+    }
+)
+
+
+async def async_get_conditions(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List available device conditions for mower entities."""
+    registry = er.async_get(hass)
+    conditions: list[dict[str, str]] = []
+
+    for entry in er.async_entries_for_device(registry, device_id):
+        if entry.domain != MOWER_DOMAIN or entry.platform != DOMAIN:
+            continue
+
+        base_condition = {
+            CONF_CONDITION: "device",
+            CONF_DEVICE_ID: device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: entry.id,
+        }
+        conditions.extend(
+            {**base_condition, CONF_TYPE: condition_type}
+            for condition_type in CONDITION_STATE_MAP
+        )
+
+    return conditions
+
+
+@callback
+def async_condition_from_config(
+    hass: HomeAssistant, config: ConfigType
+) -> condition.ConditionCheckerType:
+    """Create a function to test a device condition."""
+    test_states = CONDITION_STATE_MAP[config[CONF_TYPE]]
+
+    registry = er.async_get(hass)
+    entity_id = er.async_resolve_entity_id(registry, config[CONF_ENTITY_ID])
+
+    def test_is_state(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
+        """Test if the mower entity matches one of the expected states."""
+        del variables
+        return (
+            entity_id is not None
+            and (state := hass.states.get(entity_id)) is not None
+            and state.state in test_states
+        )
+
+    return test_is_state

--- a/custom_components/landroid_cloud/device_trigger.py
+++ b/custom_components/landroid_cloud/device_trigger.py
@@ -1,0 +1,98 @@
+"""Provides device triggers for Landroid Cloud devices."""
+
+from __future__ import annotations
+
+from typing import Final
+
+import voluptuous as vol
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.homeassistant.triggers import state as state_trigger
+from homeassistant.components.lawn_mower import LawnMowerActivity
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_FOR,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.typing import ConfigType
+
+from . import DOMAIN
+
+MOWER_DOMAIN: Final = "lawn_mower"
+TRIGGER_STATE_MAP: Final[dict[str, str]] = {
+    "mowing": LawnMowerActivity.MOWING,
+    "docked": LawnMowerActivity.DOCKED,
+    "error": LawnMowerActivity.ERROR,
+    "returning": LawnMowerActivity.RETURNING,
+}
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_STATE_MAP),
+        vol.Optional(CONF_FOR): cv.positive_time_period_dict,
+    }
+)
+
+
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List available device triggers for mower entities."""
+    registry = er.async_get(hass)
+    triggers: list[dict[str, str]] = []
+
+    for entry in er.async_entries_for_device(registry, device_id):
+        if entry.domain != MOWER_DOMAIN or entry.platform != DOMAIN:
+            continue
+
+        triggers.extend(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.id,
+                CONF_TYPE: trigger_type,
+            }
+            for trigger_type in TRIGGER_STATE_MAP
+        )
+
+    return triggers
+
+
+async def async_get_trigger_capabilities(
+    hass: HomeAssistant, config: ConfigType
+) -> dict[str, vol.Schema]:
+    """List trigger capabilities."""
+    del hass, config
+    return {
+        "extra_fields": vol.Schema(
+            {vol.Optional(CONF_FOR): cv.positive_time_period_dict}
+        )
+    }
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a state trigger for the selected mower activity."""
+    state_config = {
+        CONF_PLATFORM: "state",
+        CONF_ENTITY_ID: config[CONF_ENTITY_ID],
+        state_trigger.CONF_TO: TRIGGER_STATE_MAP[config[CONF_TYPE]],
+    }
+    if CONF_FOR in config:
+        state_config[CONF_FOR] = config[CONF_FOR]
+
+    state_config = await state_trigger.async_validate_trigger_config(hass, state_config)
+    return await state_trigger.async_attach_trigger(
+        hass, state_config, action, trigger_info, platform_type="device"
+    )

--- a/custom_components/landroid_cloud/translations/cs.json
+++ b/custom_components/landroid_cloud/translations/cs.json
@@ -204,5 +204,27 @@
         "name": "Zóna"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Nechte {entity_name} začít sekat",
+      "pause": "Pozastavit {entity_name}",
+      "dock": "Poslat {entity_name} zpět do nabíjecí stanice"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} seká",
+      "is_docked": "{entity_name} je v nabíjecí stanici",
+      "has_error": "{entity_name} hlásí chybu",
+      "is_returning": "{entity_name} se vrací do nabíjecí stanice"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} začal sekat",
+      "docked": "{entity_name} dorazil do nabíjecí stanice",
+      "error": "{entity_name} přešel do chybového stavu",
+      "returning": "{entity_name} se začal vracet do nabíjecí stanice"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/da.json
+++ b/custom_components/landroid_cloud/translations/da.json
@@ -139,6 +139,28 @@
       }
     }
   },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Lad {entity_name} starte klipningen",
+      "pause": "Sæt {entity_name} på pause",
+      "dock": "Lad {entity_name} køre tilbage til ladestationen"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} klipper",
+      "is_docked": "{entity_name} er i ladestationen",
+      "has_error": "{entity_name} har en fejl",
+      "is_returning": "{entity_name} er på vej tilbage til ladestationen"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} begyndte at klippe",
+      "docked": "{entity_name} kørte ind i ladestationen",
+      "error": "{entity_name} gik i fejltilstand",
+      "returning": "{entity_name} begyndte at køre tilbage til ladestationen"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
+  },
   "entity": {
     "sensor": {
       "battery": {

--- a/custom_components/landroid_cloud/translations/de.json
+++ b/custom_components/landroid_cloud/translations/de.json
@@ -204,5 +204,27 @@
         "name": "Zone"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Lassen Sie {entity_name} mit dem Mähen beginnen",
+      "pause": "Pausieren Sie {entity_name}",
+      "dock": "Lassen Sie {entity_name} zur Ladestation zurückkehren"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} mäht",
+      "is_docked": "{entity_name} ist angedockt",
+      "has_error": "{entity_name} hat einen Fehler",
+      "is_returning": "{entity_name} kehrt zur Ladestation zurück"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} hat mit dem Mähen begonnen",
+      "docked": "{entity_name} hat die Ladestation erreicht",
+      "error": "{entity_name} ist in einen Fehlerzustand gewechselt",
+      "returning": "{entity_name} hat die Rückkehr zur Ladestation begonnen"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/en.json
+++ b/custom_components/landroid_cloud/translations/en.json
@@ -139,6 +139,28 @@
       }
     }
   },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Let {entity_name} start mowing",
+      "pause": "Pause {entity_name}",
+      "dock": "Let {entity_name} return to the charging station"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} is mowing",
+      "is_docked": "{entity_name} is docked",
+      "has_error": "{entity_name} has an error",
+      "is_returning": "{entity_name} is returning to the charging station"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} started mowing",
+      "docked": "{entity_name} docked",
+      "error": "{entity_name} entered an error state",
+      "returning": "{entity_name} started returning to the charging station"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
+  },
   "entity": {
     "sensor": {
       "battery": {

--- a/custom_components/landroid_cloud/translations/es.json
+++ b/custom_components/landroid_cloud/translations/es.json
@@ -204,5 +204,27 @@
         "name": "Zona"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Haz que {entity_name} empiece a cortar el césped",
+      "pause": "Pausa {entity_name}",
+      "dock": "Haz que {entity_name} vuelva a la estación de carga"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} está cortando el césped",
+      "is_docked": "{entity_name} está en la estación de carga",
+      "has_error": "{entity_name} tiene un error",
+      "is_returning": "{entity_name} está volviendo a la estación de carga"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} comenzó a cortar el césped",
+      "docked": "{entity_name} llegó a la estación de carga",
+      "error": "{entity_name} entró en estado de error",
+      "returning": "{entity_name} comenzó a volver a la estación de carga"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/et.json
+++ b/custom_components/landroid_cloud/translations/et.json
@@ -204,5 +204,27 @@
         "name": "Tsoon"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Lase {entity_name} niitmist alustada",
+      "pause": "Peata {entity_name}",
+      "dock": "Saada {entity_name} tagasi laadimisjaama"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} niidab",
+      "is_docked": "{entity_name} on laadimisjaamas",
+      "has_error": "{entity_name} on veaseisundis",
+      "is_returning": "{entity_name} liigub tagasi laadimisjaama"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} alustas niitmist",
+      "docked": "{entity_name} jõudis laadimisjaama",
+      "error": "{entity_name} läks veaseisundisse",
+      "returning": "{entity_name} alustas tagasisõitu laadimisjaama"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/fr.json
+++ b/custom_components/landroid_cloud/translations/fr.json
@@ -204,5 +204,27 @@
         "name": "Zone"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Lancer la tonte de {entity_name}",
+      "pause": "Mettre {entity_name} en pause",
+      "dock": "Faire revenir {entity_name} à la station de charge"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} est en train de tondre",
+      "is_docked": "{entity_name} est à la station de charge",
+      "has_error": "{entity_name} est en erreur",
+      "is_returning": "{entity_name} retourne à la station de charge"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} a commencé à tondre",
+      "docked": "{entity_name} est revenu à la station de charge",
+      "error": "{entity_name} est passé en erreur",
+      "returning": "{entity_name} a commencé à revenir vers la station de charge"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/hu.json
+++ b/custom_components/landroid_cloud/translations/hu.json
@@ -204,5 +204,27 @@
         "name": "Zóna"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "A(z) {entity_name} kezdje meg a fűnyírást",
+      "pause": "A(z) {entity_name} szüneteltetése",
+      "dock": "A(z) {entity_name} térjen vissza a töltőállomásra"
+    },
+    "condition_type": {
+      "is_mowing": "A(z) {entity_name} füvet nyír",
+      "is_docked": "A(z) {entity_name} a töltőállomáson van",
+      "has_error": "A(z) {entity_name} hibát jelez",
+      "is_returning": "A(z) {entity_name} visszatér a töltőállomásra"
+    },
+    "trigger_type": {
+      "mowing": "A(z) {entity_name} megkezdte a fűnyírást",
+      "docked": "A(z) {entity_name} elérte a töltőállomást",
+      "error": "A(z) {entity_name} hibás állapotba került",
+      "returning": "A(z) {entity_name} megkezdte a visszatérést a töltőállomásra"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/it.json
+++ b/custom_components/landroid_cloud/translations/it.json
@@ -204,5 +204,27 @@
         "name": "Zona"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Avvia il taglio con {entity_name}",
+      "pause": "Metti in pausa {entity_name}",
+      "dock": "Fai tornare {entity_name} alla stazione di ricarica"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} sta tagliando il prato",
+      "is_docked": "{entity_name} si trova alla stazione di ricarica",
+      "has_error": "{entity_name} segnala un errore",
+      "is_returning": "{entity_name} sta tornando alla stazione di ricarica"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} ha iniziato a tagliare il prato",
+      "docked": "{entity_name} è tornato alla stazione di ricarica",
+      "error": "{entity_name} è entrato in stato di errore",
+      "returning": "{entity_name} ha iniziato a tornare alla stazione di ricarica"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/nb.json
+++ b/custom_components/landroid_cloud/translations/nb.json
@@ -204,5 +204,27 @@
         "name": "Sone"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "La {entity_name} starte klippingen",
+      "pause": "Sett {entity_name} på pause",
+      "dock": "La {entity_name} kjøre tilbake til ladestasjonen"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} klipper",
+      "is_docked": "{entity_name} står i ladestasjonen",
+      "has_error": "{entity_name} har en feil",
+      "is_returning": "{entity_name} er på vei tilbake til ladestasjonen"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} begynte å klippe",
+      "docked": "{entity_name} kjørte inn i ladestasjonen",
+      "error": "{entity_name} gikk over i feiltilstand",
+      "returning": "{entity_name} begynte å kjøre tilbake til ladestasjonen"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/nl.json
+++ b/custom_components/landroid_cloud/translations/nl.json
@@ -204,5 +204,27 @@
         "name": "Zone"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Laat {entity_name} beginnen met maaien",
+      "pause": "Pauzeer {entity_name}",
+      "dock": "Laat {entity_name} terugkeren naar het laadstation"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} maait",
+      "is_docked": "{entity_name} staat in het laadstation",
+      "has_error": "{entity_name} heeft een fout",
+      "is_returning": "{entity_name} keert terug naar het laadstation"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} is begonnen met maaien",
+      "docked": "{entity_name} is teruggekeerd naar het laadstation",
+      "error": "{entity_name} is in een foutstatus gekomen",
+      "returning": "{entity_name} is begonnen met terugkeren naar het laadstation"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/no.json
+++ b/custom_components/landroid_cloud/translations/no.json
@@ -204,5 +204,27 @@
         "name": "Sone"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "La {entity_name} starte klippingen",
+      "pause": "Sett {entity_name} på pause",
+      "dock": "La {entity_name} kjøre tilbake til ladestasjonen"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} klipper",
+      "is_docked": "{entity_name} står i ladestasjonen",
+      "has_error": "{entity_name} har en feil",
+      "is_returning": "{entity_name} er på vei tilbake til ladestasjonen"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} begynte å klippe",
+      "docked": "{entity_name} kjørte inn i ladestasjonen",
+      "error": "{entity_name} gikk over i feiltilstand",
+      "returning": "{entity_name} begynte å kjøre tilbake til ladestasjonen"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/pl.json
+++ b/custom_components/landroid_cloud/translations/pl.json
@@ -204,5 +204,27 @@
         "name": "Strefa"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Niech {entity_name} rozpocznie koszenie",
+      "pause": "Wstrzymaj {entity_name}",
+      "dock": "Niech {entity_name} wróci do stacji ładującej"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} kosi",
+      "is_docked": "{entity_name} znajduje się w stacji ładującej",
+      "has_error": "{entity_name} zgłasza błąd",
+      "is_returning": "{entity_name} wraca do stacji ładującej"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} rozpoczęła koszenie",
+      "docked": "{entity_name} wróciła do stacji ładującej",
+      "error": "{entity_name} przeszła w stan błędu",
+      "returning": "{entity_name} rozpoczęła powrót do stacji ładującej"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/ro.json
+++ b/custom_components/landroid_cloud/translations/ro.json
@@ -204,5 +204,27 @@
         "name": "Zonă"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Pornește tunderea pentru {entity_name}",
+      "pause": "Pune pe pauză {entity_name}",
+      "dock": "Trimite {entity_name} înapoi la stația de încărcare"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} tunde",
+      "is_docked": "{entity_name} este în stația de încărcare",
+      "has_error": "{entity_name} are o eroare",
+      "is_returning": "{entity_name} se întoarce la stația de încărcare"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} a început să tundă",
+      "docked": "{entity_name} a ajuns în stația de încărcare",
+      "error": "{entity_name} a intrat în stare de eroare",
+      "returning": "{entity_name} a început să se întoarcă la stația de încărcare"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/ru.json
+++ b/custom_components/landroid_cloud/translations/ru.json
@@ -204,5 +204,27 @@
         "name": "Зона"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Запустить кошение для {entity_name}",
+      "pause": "Приостановить {entity_name}",
+      "dock": "Отправить {entity_name} обратно на зарядную станцию"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} косит газон",
+      "is_docked": "{entity_name} находится на зарядной станции",
+      "has_error": "{entity_name} сообщает об ошибке",
+      "is_returning": "{entity_name} возвращается на зарядную станцию"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} начал косить",
+      "docked": "{entity_name} вернулся на зарядную станцию",
+      "error": "{entity_name} перешёл в состояние ошибки",
+      "returning": "{entity_name} начал возвращаться на зарядную станцию"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/custom_components/landroid_cloud/translations/sv.json
+++ b/custom_components/landroid_cloud/translations/sv.json
@@ -204,5 +204,27 @@
         "name": "Zon"
       }
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_mowing": "Låt {entity_name} börja klippa",
+      "pause": "Pausa {entity_name}",
+      "dock": "Låt {entity_name} köra tillbaka till laddstationen"
+    },
+    "condition_type": {
+      "is_mowing": "{entity_name} klipper",
+      "is_docked": "{entity_name} står i laddstationen",
+      "has_error": "{entity_name} har ett fel",
+      "is_returning": "{entity_name} är på väg tillbaka till laddstationen"
+    },
+    "trigger_type": {
+      "mowing": "{entity_name} började klippa",
+      "docked": "{entity_name} körde in i laddstationen",
+      "error": "{entity_name} gick in i felläge",
+      "returning": "{entity_name} började köra tillbaka till laddstationen"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    }
   }
 }

--- a/tests/test_device_action.py
+++ b/tests/test_device_action.py
@@ -1,0 +1,154 @@
+"""Tests for Landroid Cloud device actions."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from homeassistant.components.lawn_mower import LawnMowerEntityFeature
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_TYPE,
+)
+import pytest
+
+from custom_components.landroid_cloud import DOMAIN
+from custom_components.landroid_cloud.device_action import (
+    async_call_action_from_config,
+    async_get_actions,
+    async_validate_action_config,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_actions_returns_supported_mower_actions(monkeypatch) -> None:
+    """Device actions should expose supported mower commands only."""
+    registry = object()
+    mower_entry = SimpleNamespace(
+        domain="lawn_mower",
+        platform=DOMAIN,
+        id="registry-entry-id",
+        entity_id="lawn_mower.front_yard",
+    )
+    ignored_wrong_platform = SimpleNamespace(
+        domain="lawn_mower",
+        platform="other_integration",
+        id="other-entry",
+        entity_id="lawn_mower.other",
+    )
+    ignored_wrong_domain = SimpleNamespace(
+        domain="sensor",
+        platform=DOMAIN,
+        id="sensor-entry",
+        entity_id="sensor.front_yard_status",
+    )
+
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_action.er.async_get",
+        lambda hass: registry,
+    )
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_action.er.async_entries_for_device",
+        lambda _registry, _device_id: [
+            mower_entry,
+            ignored_wrong_platform,
+            ignored_wrong_domain,
+        ],
+    )
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_action.get_supported_features",
+        lambda hass, entity_id: LawnMowerEntityFeature.START_MOWING
+        | LawnMowerEntityFeature.DOCK
+        if entity_id == mower_entry.entity_id
+        else LawnMowerEntityFeature(0),
+    )
+
+    actions = await async_get_actions(SimpleNamespace(), "device-123")
+
+    assert actions == [
+        {
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "registry-entry-id",
+            CONF_TYPE: "start_mowing",
+        },
+        {
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "registry-entry-id",
+            CONF_TYPE: "dock",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_validate_action_config_resolves_registry_entry(monkeypatch) -> None:
+    """Validation should resolve entity registry ids to entity ids."""
+    registry_entry_id = "1234567890abcdef1234567890abcdef"
+
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_action.er.async_get",
+        lambda hass: object(),
+    )
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_action.er.async_resolve_entity_id",
+        lambda registry, entity_id: "lawn_mower.front_yard"
+        if entity_id == registry_entry_id
+        else entity_id,
+    )
+
+    validated = await async_validate_action_config(
+        SimpleNamespace(),
+        {
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: registry_entry_id,
+            CONF_TYPE: "pause",
+        },
+    )
+
+    assert validated == {
+        CONF_DEVICE_ID: "device-123",
+        CONF_DOMAIN: DOMAIN,
+        CONF_ENTITY_ID: "lawn_mower.front_yard",
+        CONF_TYPE: "pause",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("action_type", "service"),
+    [
+        ("start_mowing", "start_mowing"),
+        ("pause", "pause"),
+        ("dock", "dock"),
+    ],
+)
+async def test_call_action_from_config_calls_lawn_mower_service(
+    action_type: str, service: str
+) -> None:
+    """Executing a device action should call the standard mower service."""
+    hass = SimpleNamespace(services=SimpleNamespace(async_call=AsyncMock()))
+
+    await async_call_action_from_config(
+        hass,
+        {
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "lawn_mower.front_yard",
+            CONF_TYPE: action_type,
+        },
+        variables={},
+        context=None,
+    )
+
+    hass.services.async_call.assert_awaited_once_with(
+        "lawn_mower",
+        service,
+        {ATTR_ENTITY_ID: "lawn_mower.front_yard"},
+        blocking=True,
+        context=None,
+    )

--- a/tests/test_device_condition.py
+++ b/tests/test_device_condition.py
@@ -1,0 +1,145 @@
+"""Tests for Landroid Cloud device conditions."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from homeassistant.components.lawn_mower import LawnMowerActivity
+from homeassistant.const import (
+    CONF_CONDITION,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_TYPE,
+)
+import pytest
+
+from custom_components.landroid_cloud import DOMAIN
+from custom_components.landroid_cloud.device_condition import (
+    async_condition_from_config,
+    async_get_conditions,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_conditions_returns_supported_mower_conditions(
+    monkeypatch,
+) -> None:
+    """Device conditions should be exposed for mower entities only."""
+    registry = object()
+    mower_entry = SimpleNamespace(
+        domain="lawn_mower",
+        platform=DOMAIN,
+        id="registry-entry-id",
+        entity_id="lawn_mower.front_yard",
+    )
+    ignored_entry = SimpleNamespace(
+        domain="lawn_mower",
+        platform="other_integration",
+        id="other-entry",
+        entity_id="lawn_mower.other",
+    )
+
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_condition.er.async_get",
+        lambda hass: registry,
+    )
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_condition.er.async_entries_for_device",
+        lambda _registry, _device_id: [mower_entry, ignored_entry],
+    )
+
+    conditions = await async_get_conditions(SimpleNamespace(), "device-123")
+
+    assert conditions == [
+        {
+            CONF_CONDITION: "device",
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "registry-entry-id",
+            CONF_TYPE: "is_mowing",
+        },
+        {
+            CONF_CONDITION: "device",
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "registry-entry-id",
+            CONF_TYPE: "is_docked",
+        },
+        {
+            CONF_CONDITION: "device",
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "registry-entry-id",
+            CONF_TYPE: "has_error",
+        },
+        {
+            CONF_CONDITION: "device",
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "registry-entry-id",
+            CONF_TYPE: "is_returning",
+        },
+    ]
+
+
+def test_condition_from_config_matches_resolved_entity_state(monkeypatch) -> None:
+    """Condition checker should resolve registry ids and inspect mower state."""
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_condition.er.async_get",
+        lambda hass: object(),
+    )
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_condition.er.async_resolve_entity_id",
+        lambda registry, entity_id: "lawn_mower.front_yard",
+    )
+    hass = SimpleNamespace(
+        states=SimpleNamespace(
+            get=lambda entity_id: SimpleNamespace(state=LawnMowerActivity.RETURNING)
+            if entity_id == "lawn_mower.front_yard"
+            else None
+        )
+    )
+
+    checker = async_condition_from_config(
+        hass,
+        {
+            CONF_CONDITION: "device",
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "1234567890abcdef1234567890abcdef",
+            CONF_TYPE: "is_returning",
+        },
+    )
+
+    assert checker(hass, {}) is True
+
+
+def test_condition_from_config_rejects_non_matching_state(monkeypatch) -> None:
+    """Condition checker should return false when the mower is in another state."""
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_condition.er.async_get",
+        lambda hass: object(),
+    )
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_condition.er.async_resolve_entity_id",
+        lambda registry, entity_id: "lawn_mower.front_yard",
+    )
+    hass = SimpleNamespace(
+        states=SimpleNamespace(
+            get=lambda entity_id: SimpleNamespace(state=LawnMowerActivity.DOCKED)
+        )
+    )
+
+    checker = async_condition_from_config(
+        hass,
+        {
+            CONF_CONDITION: "device",
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "1234567890abcdef1234567890abcdef",
+            CONF_TYPE: "has_error",
+        },
+    )
+
+    assert checker(hass, {}) is False

--- a/tests/test_device_trigger.py
+++ b/tests/test_device_trigger.py
@@ -1,0 +1,142 @@
+"""Tests for Landroid Cloud device triggers."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+from homeassistant.components.lawn_mower import LawnMowerActivity
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_FOR,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+import pytest
+
+from custom_components.landroid_cloud import DOMAIN
+from custom_components.landroid_cloud.device_trigger import (
+    async_attach_trigger,
+    async_get_trigger_capabilities,
+    async_get_triggers,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_triggers_returns_supported_mower_triggers(monkeypatch) -> None:
+    """Device triggers should be exposed for mower entities only."""
+    registry = object()
+    mower_entry = SimpleNamespace(
+        domain="lawn_mower",
+        platform=DOMAIN,
+        id="registry-entry-id",
+        entity_id="lawn_mower.front_yard",
+    )
+    ignored_entry = SimpleNamespace(
+        domain="sensor",
+        platform=DOMAIN,
+        id="sensor-entry",
+        entity_id="sensor.front_yard_status",
+    )
+
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_trigger.er.async_get",
+        lambda hass: registry,
+    )
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_trigger.er.async_entries_for_device",
+        lambda _registry, _device_id: [mower_entry, ignored_entry],
+    )
+
+    triggers = await async_get_triggers(SimpleNamespace(), "device-123")
+
+    assert triggers == [
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "registry-entry-id",
+            CONF_TYPE: "mowing",
+        },
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "registry-entry-id",
+            CONF_TYPE: "docked",
+        },
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "registry-entry-id",
+            CONF_TYPE: "error",
+        },
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "registry-entry-id",
+            CONF_TYPE: "returning",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_trigger_capabilities_supports_for() -> None:
+    """Trigger capabilities should expose the optional duration field."""
+    capabilities = await async_get_trigger_capabilities(SimpleNamespace(), {})
+    schema = capabilities["extra_fields"]
+    validated = schema({CONF_FOR: {"minutes": 5}})
+
+    assert validated == {CONF_FOR: timedelta(minutes=5)}
+
+
+@pytest.mark.asyncio
+async def test_attach_trigger_builds_state_trigger(monkeypatch) -> None:
+    """Trigger attachment should delegate to a state trigger with mower state."""
+    validated_config: dict | None = None
+
+    async def _validate(_hass, config):
+        nonlocal validated_config
+        validated_config = config
+        return config
+
+    async def _attach(_hass, config, action, trigger_info, platform_type):
+        assert action == "callback"
+        assert trigger_info == "info"
+        assert platform_type == "device"
+        return "remove-callback"
+
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_trigger.state_trigger.async_validate_trigger_config",
+        _validate,
+    )
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.device_trigger.state_trigger.async_attach_trigger",
+        _attach,
+    )
+
+    result = await async_attach_trigger(
+        SimpleNamespace(),
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: "device-123",
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: "lawn_mower.front_yard",
+            CONF_TYPE: "returning",
+            CONF_FOR: {"minutes": 1},
+        },
+        action="callback",
+        trigger_info="info",
+    )
+
+    assert result == "remove-callback"
+    assert validated_config == {
+        CONF_PLATFORM: "state",
+        CONF_ENTITY_ID: "lawn_mower.front_yard",
+        "to": LawnMowerActivity.RETURNING,
+        CONF_FOR: {"minutes": 1},
+    }


### PR DESCRIPTION
## Summary
This PR restores device automations for the v7 mower entity model.

It adds device actions, device conditions, and device triggers for the integration's `lawn_mower` entities and wires them to Home Assistant's standard mower services and states.

## Test Strategy
Automated tests:
- `pytest -q tests/test_device_action.py tests/test_device_condition.py tests/test_device_trigger.py tests/test_lawn_mower.py`
- `ruff check --fix custom_components/landroid_cloud/device_action.py custom_components/landroid_cloud/device_condition.py custom_components/landroid_cloud/device_trigger.py tests/test_device_action.py tests/test_device_condition.py tests/test_device_trigger.py tests/test_lawn_mower.py`

## Known Limitations
This PR restores the automation surface for the current v7 mower state model only. Legacy fine-grained mower runtime states are handled separately in a stacked follow-up PR.

## Configuration Changes
No configuration changes are required.

## Semver
Proposed semver label: `minor`.
Per repository rules, no label has been set yet; please confirm before it is applied.
