### PR TITLE
Hide zero-valued remaining rain delay

### DIFF
--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -47,7 +47,7 @@ def _battery_charging_attribute(device) -> dict[str, bool] | None:
 def _rain_delay_remaining_value(device) -> int | None:
     """Return remaining rain delay in minutes when available."""
     remaining = getattr(device, "rainsensor", {}).get("remaining")
-    if isinstance(remaining, int):
+    if isinstance(remaining, int) and remaining > 0:
         return remaining
     return None
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -65,6 +65,12 @@ def test_rain_delay_remaining_value_returns_minutes() -> None:
     assert _rain_delay_remaining_value(device) == 42
 
 
+def test_rain_delay_remaining_value_zero_is_unavailable() -> None:
+    """Rain delay remaining should be unavailable when no delay is active."""
+    device = SimpleNamespace(rainsensor={"remaining": 0})
+    assert _rain_delay_remaining_value(device) is None
+
+
 def test_rain_delay_remaining_value_unavailable() -> None:
     """Rain delay remaining should be unknown for non-integer values."""
     device = SimpleNamespace(rainsensor={"remaining": "42"})


### PR DESCRIPTION
## Summary
This PR makes the remaining rain delay sensor unavailable when the cloud reports `0` minutes remaining.

That keeps the entity aligned with the intended meaning of the sensor: it now only exposes a value while a rain delay is actually active.

## Test Strategy
Automated tests:
- `pytest -q tests/test_sensor.py`
- `ruff check --fix custom_components/landroid_cloud/sensor.py tests/test_sensor.py`

## Known Limitations
This change only adjusts the sensor value handling for `rain_delay_remaining`. It does not change any other rain-delay related entities or attributes.

## Configuration Changes
No configuration changes are required.

## Semver
Proposed semver label: `patch`.
Per repository rules, no label has been set yet; please confirm before it is applied.
