### PR TITLE
Make inactive rain delay remaining sensor unavailable

### DIFF
--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -437,6 +437,8 @@ class LandroidSensor(LandroidBaseEntity, SensorEntity):
             return False
         if self.entity_description.key == "next_schedule":
             return _next_schedule_value(self.device) is not None
+        if self.entity_description.key == "rain_delay_remaining":
+            return _rain_delay_remaining_value(self.device) is not None
         return True
 
     @property

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -391,6 +391,21 @@ def test_next_schedule_sensor_stays_available_with_valid_schedule(monkeypatch) -
     assert entity.available is True
 
 
+def test_rain_delay_remaining_sensor_is_unavailable_when_zero() -> None:
+    """Rain delay remaining sensor should be unavailable when delay is inactive."""
+    entity = object.__new__(LandroidSensor)
+    entity.entity_description = next(
+        description for description in SENSORS if description.key == "rain_delay_remaining"
+    )
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data={"serial": SimpleNamespace(rainsensor={"remaining": 0})},
+    )
+    entity._serial_number = "serial"
+
+    assert entity.available is False
+
+
 def test_battery_cycle_value_returns_integer() -> None:
     """Battery cycle values should be exposed when present."""
     device = SimpleNamespace(battery={"cycles": {"total": 3014, "current": 14}})


### PR DESCRIPTION
## Summary
This PR fixes the remaining rain delay sensor so it becomes unavailable when no rain delay is active.

The earlier change stopped returning `0` as a sensor value, but the entity still stayed available, which caused Home Assistant to show `unknown` instead of `unavailable`. This PR updates the sensor availability logic to match the intended behavior.

## Test Strategy
Automated tests:
- `pytest -q tests/test_sensor.py`
- `ruff check --fix custom_components/landroid_cloud/sensor.py tests/test_sensor.py`

## Known Limitations
This change only affects the availability behavior of `rain_delay_remaining` when the remaining delay is `0` or otherwise unavailable.

## Configuration Changes
No configuration changes are required.

## Semver
Proposed semver label: `patch`.
Per repository rules, no label has been set yet; please confirm before it is applied.
