### PR TITLE
Document rain delay remaining availability behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ You can find installation instructions on [this Github repo](https://github.com/
 
 
 ### Other useful information
+#### Rain delay remaining sensor
+
+The `rain_delay_remaining` sensor is only available while a rain delay is active.
+When the mower reports `0` minutes remaining, the sensor is exposed as unavailable instead of reporting `0`.
+
 #### Services and app stopped working
 
 You might experience being banned from Worx Landroid Cloud service.


### PR DESCRIPTION
## Summary
This PR documents the intended behavior of the `rain_delay_remaining` sensor in the README.

It now explicitly states that the sensor is only available while a rain delay is active, and that a reported remaining value of `0` is surfaced as unavailable instead of `0`.

## Test Strategy
Documentation-only change.

## Known Limitations
This PR only updates the documentation and does not change runtime behavior.

## Configuration Changes
No configuration changes are required.

## Semver
Proposed semver label: `patch`.
Per repository rules, no label has been set yet; please confirm before it is applied.
