### PR TITLE
Add Home Assistant service icons for custom services

### DIFF
--- a/custom_components/landroid_cloud/icons.json
+++ b/custom_components/landroid_cloud/icons.json
@@ -1,0 +1,16 @@
+{
+  "services": {
+    "ots": {
+      "service": "mdi:calendar-play"
+    },
+    "add_schedule": {
+      "service": "mdi:calendar-plus"
+    },
+    "edit_schedule": {
+      "service": "mdi:calendar-edit"
+    },
+    "delete_schedule": {
+      "service": "mdi:calendar-remove"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add `icons.json` for the integration's custom services using Home Assistant's current service icon schema.

This adds icons for:
- `landroid_cloud.ots`
- `landroid_cloud.add_schedule`
- `landroid_cloud.edit_schedule`
- `landroid_cloud.delete_schedule`

The icon choices are intentionally task-specific:
- one-time schedule uses `mdi:calendar-play`
- add schedule uses `mdi:calendar-plus`
- edit schedule uses `mdi:calendar-edit`
- delete schedule uses `mdi:calendar-remove`

## Test strategy
- Validated `custom_components/landroid_cloud/icons.json` with `python -m json.tool`
- Rebased branch onto current `master`

## Known limitations
- This PR only adds service icons for the custom services currently exposed in v7
- No runtime behavior changes are included

## Configuration changes
- None
