### PR TITLE
Make daily progress unavailable when missing

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -13,7 +13,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud @ git+https://github.com/mtrab/pyworxcloud.git@fix/daily-progress-none-without-today-schedule"
+        "pyworxcloud@git+https://github.com/mtrab/pyworxcloud.git@master"
     ],
     "version": "7.0.0b3"
 }

--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -53,6 +53,14 @@ def _rain_delay_remaining_value(device) -> int | None:
     return None
 
 
+def _daily_progress_value(device) -> int | None:
+    """Return daily progress percentage when available."""
+    progress = getattr(device, "schedules", {}).get("daily_progress")
+    if isinstance(progress, int):
+        return progress
+    return None
+
+
 def _battery_cycle_value(device, cycle_key: str) -> int | None:
     """Return battery cycle information when available."""
     cycles = getattr(device, "battery", {}).get("cycles", {})
@@ -475,6 +483,8 @@ class LandroidSensor(LandroidBaseEntity, SensorEntity):
             return _next_schedule_value(self.device) is not None
         if self.entity_description.key == "rain_delay_remaining":
             return _rain_delay_remaining_value(self.device) is not None
+        if self.entity_description.key == "daily_progress":
+            return _daily_progress_value(self.device) is not None
         return True
 
     @property
@@ -490,7 +500,7 @@ class LandroidSensor(LandroidBaseEntity, SensorEntity):
         if key == "rssi":
             return getattr(device, "rssi", None)
         if key == "daily_progress":
-            return device.schedules.get("daily_progress")
+            return _daily_progress_value(device)
         if key == "next_schedule":
             return _next_schedule_value(device)
         if key == "rain_delay_remaining":

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -18,6 +18,7 @@ from custom_components.landroid_cloud.sensor import (
     _battery_value,
     _blade_reset_time_value,
     _blade_runtime_value,
+    _daily_progress_value,
     _last_update_value,
     _next_schedule_value,
     _normalized_schedule_attributes,
@@ -76,6 +77,18 @@ def test_rain_delay_remaining_value_unavailable() -> None:
     """Rain delay remaining should be unknown for non-integer values."""
     device = SimpleNamespace(rainsensor={"remaining": "42"})
     assert _rain_delay_remaining_value(device) is None
+
+
+def test_daily_progress_value_returns_integer() -> None:
+    """Daily progress should be exposed when present as an integer."""
+    device = SimpleNamespace(schedules={"daily_progress": 0})
+    assert _daily_progress_value(device) == 0
+
+
+def test_daily_progress_value_none_is_unavailable() -> None:
+    """Daily progress should be unavailable when pyworxcloud returns None."""
+    device = SimpleNamespace(schedules={"daily_progress": None})
+    assert _daily_progress_value(device) is None
 
 
 def test_orientation_value_returns_axis_degrees() -> None:
@@ -429,6 +442,36 @@ def test_rain_delay_remaining_sensor_is_unavailable_when_zero() -> None:
     entity._serial_number = "serial"
 
     assert entity.available is False
+
+
+def test_daily_progress_sensor_is_unavailable_when_none() -> None:
+    """Daily progress sensor should be unavailable when pyworxcloud returns None."""
+    entity = object.__new__(LandroidSensor)
+    entity.entity_description = next(
+        description for description in SENSORS if description.key == "daily_progress"
+    )
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data={"serial": SimpleNamespace(schedules={"daily_progress": None})},
+    )
+    entity._serial_number = "serial"
+
+    assert entity.available is False
+
+
+def test_daily_progress_sensor_stays_available_with_zero() -> None:
+    """Daily progress sensor should stay available for a valid zero value."""
+    entity = object.__new__(LandroidSensor)
+    entity.entity_description = next(
+        description for description in SENSORS if description.key == "daily_progress"
+    )
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data={"serial": SimpleNamespace(schedules={"daily_progress": 0})},
+    )
+    entity._serial_number = "serial"
+
+    assert entity.available is True
 
 
 def test_battery_cycle_value_returns_integer() -> None:


### PR DESCRIPTION
## Summary
Make the `daily_progress` sensor unavailable when the upstream data source returns `None`.

This keeps the sensor aligned with the intended Home Assistant behavior:
- a missing value becomes `unavailable`
- a real `0` value remains available

The PR also pins `pyworxcloud` to the current `master` branch for this test cycle.

## Test strategy
- `ruff check --fix custom_components/landroid_cloud/sensor.py tests/test_sensor.py`
- `pytest -q tests/test_sensor.py`
- `python -m json.tool custom_components/landroid_cloud/manifest.json`

## Known limitations
- `pyworxcloud` is temporarily installed from its `master` branch for validation
- No translation changes are needed for this behavior-only fix

## Configuration changes
- `custom_components/landroid_cloud/manifest.json` temporarily points to `pyworxcloud` `master`
