### PR TITLE
Add rain delay mower state

### DIFF
--- a/custom_components/landroid_cloud/const.py
+++ b/custom_components/landroid_cloud/const.py
@@ -43,6 +43,7 @@ MOWER_STATE_EDGECUT = "edgecut"
 MOWER_STATE_ZONING = "zoning"
 MOWER_STATE_SEARCHING_ZONE = "searching_zone"
 MOWER_STATE_ESCAPED_DIGITAL_FENCE = "escaped_digital_fence"
+MOWER_STATE_RAIN_DELAY = "rain_delayed"
 
 
 class CloudProvider(StrEnum):

--- a/custom_components/landroid_cloud/device_condition.py
+++ b/custom_components/landroid_cloud/device_condition.py
@@ -27,6 +27,7 @@ from .const import (
     MOWER_STATE_EDGECUT,
     MOWER_STATE_ESCAPED_DIGITAL_FENCE,
     MOWER_STATE_IDLE,
+    MOWER_STATE_RAIN_DELAY,
     MOWER_STATE_SEARCHING_ZONE,
     MOWER_STATE_STARTING,
     MOWER_STATE_ZONING,
@@ -43,6 +44,7 @@ CONDITION_STATE_MAP: Final[dict[str, tuple[str, ...]]] = {
     "is_zoning": (MOWER_STATE_ZONING,),
     "is_searching_zone": (MOWER_STATE_SEARCHING_ZONE,),
     "is_idle": (MOWER_STATE_IDLE,),
+    "is_rain_delayed": (MOWER_STATE_RAIN_DELAY,),
     "is_escaped_digital_fence": (MOWER_STATE_ESCAPED_DIGITAL_FENCE,),
 }
 

--- a/custom_components/landroid_cloud/device_trigger.py
+++ b/custom_components/landroid_cloud/device_trigger.py
@@ -26,6 +26,7 @@ from .const import (
     MOWER_STATE_EDGECUT,
     MOWER_STATE_ESCAPED_DIGITAL_FENCE,
     MOWER_STATE_IDLE,
+    MOWER_STATE_RAIN_DELAY,
     MOWER_STATE_SEARCHING_ZONE,
     MOWER_STATE_STARTING,
     MOWER_STATE_ZONING,
@@ -42,6 +43,7 @@ TRIGGER_STATE_MAP: Final[dict[str, str]] = {
     "zoning": MOWER_STATE_ZONING,
     "searching_zone": MOWER_STATE_SEARCHING_ZONE,
     "idle": MOWER_STATE_IDLE,
+    "rain_delayed": MOWER_STATE_RAIN_DELAY,
     "escaped_digital_fence": MOWER_STATE_ESCAPED_DIGITAL_FENCE,
 }
 

--- a/custom_components/landroid_cloud/lawn_mower.py
+++ b/custom_components/landroid_cloud/lawn_mower.py
@@ -22,6 +22,7 @@ from .const import (
     MOWER_STATE_EDGECUT,
     MOWER_STATE_ESCAPED_DIGITAL_FENCE,
     MOWER_STATE_IDLE,
+    MOWER_STATE_RAIN_DELAY,
     MOWER_STATE_SEARCHING_ZONE,
     MOWER_STATE_STARTING,
     MOWER_STATE_ZONING,
@@ -107,6 +108,9 @@ class LandroidCloudMowerEntity(LandroidBaseEntity, LawnMowerEntity):
     @property
     def activity(self) -> str | None:
         """Return current mower activity."""
+        if self.device.raindelay_active:
+            return MOWER_STATE_RAIN_DELAY
+
         status_id = int(getattr(self.device.status, "id", -1))
         return STATUS_ACTIVITY_MAP.get(status_id, LawnMowerActivity.ERROR)
 

--- a/custom_components/landroid_cloud/translations/cs.json
+++ b/custom_components/landroid_cloud/translations/cs.json
@@ -221,7 +221,8 @@
           "idle": "Nečinný",
           "searching_zone": "Vyhledávání zóny",
           "starting": "Začínání",
-          "zoning": "Učení zóny"
+          "zoning": "Učení zóny",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} se učí zónu",
       "is_searching_zone": "{entity_name} hledá zónu",
       "is_idle": "{entity_name} je nečinný",
-      "is_escaped_digital_fence": "{entity_name} je mimo virtuální plot"
+      "is_escaped_digital_fence": "{entity_name} je mimo virtuální plot",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} začal sekat",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} začal učit zónu",
       "searching_zone": "{entity_name} začal hledat zónu",
       "idle": "{entity_name} přešel do nečinného stavu",
-      "escaped_digital_fence": "{entity_name} opustil virtuální plot"
+      "escaped_digital_fence": "{entity_name} opustil virtuální plot",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/da.json
+++ b/custom_components/landroid_cloud/translations/da.json
@@ -155,7 +155,8 @@
       "is_zoning": "{entity_name} er i gang med zone-træning",
       "is_searching_zone": "{entity_name} søger efter en zone",
       "is_idle": "{entity_name} afventer",
-      "is_escaped_digital_fence": "{entity_name} er uden for det digitale hegn"
+      "is_escaped_digital_fence": "{entity_name} er uden for det digitale hegn",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} begyndte at klippe",
@@ -167,7 +168,8 @@
       "zoning": "{entity_name} begyndte zone-træning",
       "searching_zone": "{entity_name} begyndte at søge efter en zone",
       "idle": "{entity_name} gik i ventetilstand",
-      "escaped_digital_fence": "{entity_name} kom uden for det digitale hegn"
+      "escaped_digital_fence": "{entity_name} kom uden for det digitale hegn",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"
@@ -341,7 +343,8 @@
           "idle": "Afventer",
           "searching_zone": "Søger efter zone",
           "starting": "Starter",
-          "zoning": "Zone-træning"
+          "zoning": "Zone-træning",
+          "rain_delayed": "Rain delay"
         }
       }
     }

--- a/custom_components/landroid_cloud/translations/de.json
+++ b/custom_components/landroid_cloud/translations/de.json
@@ -221,7 +221,8 @@
           "idle": "Untätig",
           "searching_zone": "Zone wird gesucht",
           "starting": "Startet",
-          "zoning": "Zonentraining"
+          "zoning": "Zonentraining",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} trainiert eine Zone",
       "is_searching_zone": "{entity_name} sucht nach einer Zone",
       "is_idle": "{entity_name} ist untätig",
-      "is_escaped_digital_fence": "{entity_name} ist außerhalb der digitalen Begrenzung"
+      "is_escaped_digital_fence": "{entity_name} ist außerhalb der digitalen Begrenzung",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} hat mit dem Mähen begonnen",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} hat das Zonentraining begonnen",
       "searching_zone": "{entity_name} hat mit der Zonensuche begonnen",
       "idle": "{entity_name} wurde untätig",
-      "escaped_digital_fence": "{entity_name} hat die digitale Begrenzung verlassen"
+      "escaped_digital_fence": "{entity_name} hat die digitale Begrenzung verlassen",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/en.json
+++ b/custom_components/landroid_cloud/translations/en.json
@@ -155,7 +155,8 @@
       "is_zoning": "{entity_name} is training a zone",
       "is_searching_zone": "{entity_name} is searching for a zone",
       "is_idle": "{entity_name} is idle",
-      "is_escaped_digital_fence": "{entity_name} is outside the digital fence"
+      "is_escaped_digital_fence": "{entity_name} is outside the digital fence",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} started mowing",
@@ -167,7 +168,8 @@
       "zoning": "{entity_name} started zone training",
       "searching_zone": "{entity_name} started searching for a zone",
       "idle": "{entity_name} became idle",
-      "escaped_digital_fence": "{entity_name} escaped the digital fence"
+      "escaped_digital_fence": "{entity_name} escaped the digital fence",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"
@@ -341,7 +343,8 @@
           "idle": "Idle",
           "searching_zone": "Searching for zone",
           "starting": "Starting",
-          "zoning": "Zone training"
+          "zoning": "Zone training",
+          "rain_delayed": "Rain delay"
         }
       }
     }

--- a/custom_components/landroid_cloud/translations/es.json
+++ b/custom_components/landroid_cloud/translations/es.json
@@ -221,7 +221,8 @@
           "idle": "Inactivo",
           "searching_zone": "Buscando zona",
           "starting": "Iniciando",
-          "zoning": "Aprendizaje de zonas"
+          "zoning": "Aprendizaje de zonas",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} está aprendiendo una zona",
       "is_searching_zone": "{entity_name} está buscando una zona",
       "is_idle": "{entity_name} está inactivo",
-      "is_escaped_digital_fence": "{entity_name} está fuera del cercado digital"
+      "is_escaped_digital_fence": "{entity_name} está fuera del cercado digital",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} comenzó a cortar el césped",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} comenzó el aprendizaje de una zona",
       "searching_zone": "{entity_name} comenzó a buscar una zona",
       "idle": "{entity_name} quedó inactivo",
-      "escaped_digital_fence": "{entity_name} salió del cercado digital"
+      "escaped_digital_fence": "{entity_name} salió del cercado digital",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/et.json
+++ b/custom_components/landroid_cloud/translations/et.json
@@ -221,7 +221,8 @@
           "idle": "Ootel",
           "searching_zone": "Tsooni otsimine",
           "starting": "Käivitamine",
-          "zoning": "Tsooni treening"
+          "zoning": "Tsooni treening",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} õpib tsooni",
       "is_searching_zone": "{entity_name} otsib tsooni",
       "is_idle": "{entity_name} on ootel",
-      "is_escaped_digital_fence": "{entity_name} on digitaalsest piirdest väljas"
+      "is_escaped_digital_fence": "{entity_name} on digitaalsest piirdest väljas",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} alustas niitmist",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} alustas tsooni treeningut",
       "searching_zone": "{entity_name} alustas tsooni otsimist",
       "idle": "{entity_name} läks ootele",
-      "escaped_digital_fence": "{entity_name} väljus digitaalsest piirdest"
+      "escaped_digital_fence": "{entity_name} väljus digitaalsest piirdest",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/fr.json
+++ b/custom_components/landroid_cloud/translations/fr.json
@@ -221,7 +221,8 @@
           "idle": "Au repos",
           "searching_zone": "Recherche de zone",
           "starting": "Démarrage",
-          "zoning": "Entraînement de zone"
+          "zoning": "Entraînement de zone",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} est en entraînement de zone",
       "is_searching_zone": "{entity_name} recherche une zone",
       "is_idle": "{entity_name} est au repos",
-      "is_escaped_digital_fence": "{entity_name} est hors de la barrière numérique"
+      "is_escaped_digital_fence": "{entity_name} est hors de la barrière numérique",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} a commencé à tondre",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} a commencé l'entraînement de zone",
       "searching_zone": "{entity_name} a commencé à rechercher une zone",
       "idle": "{entity_name} est passé au repos",
-      "escaped_digital_fence": "{entity_name} est sorti de la barrière numérique"
+      "escaped_digital_fence": "{entity_name} est sorti de la barrière numérique",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/hu.json
+++ b/custom_components/landroid_cloud/translations/hu.json
@@ -221,7 +221,8 @@
           "idle": "Tétlen",
           "searching_zone": "Zóna keresése",
           "starting": "Indulás",
-          "zoning": "Zóna betanítás"
+          "zoning": "Zóna betanítás",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "A(z) {entity_name} zónát tanul",
       "is_searching_zone": "A(z) {entity_name} zónát keres",
       "is_idle": "A(z) {entity_name} tétlen",
-      "is_escaped_digital_fence": "A(z) {entity_name} a digitális kerítésen kívül van"
+      "is_escaped_digital_fence": "A(z) {entity_name} a digitális kerítésen kívül van",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "A(z) {entity_name} megkezdte a fűnyírást",
@@ -254,7 +256,8 @@
       "zoning": "A(z) {entity_name} megkezdte a zóna betanítását",
       "searching_zone": "A(z) {entity_name} megkezdte a zóna keresését",
       "idle": "A(z) {entity_name} tétlen állapotba került",
-      "escaped_digital_fence": "A(z) {entity_name} elhagyta a digitális kerítést"
+      "escaped_digital_fence": "A(z) {entity_name} elhagyta a digitális kerítést",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/it.json
+++ b/custom_components/landroid_cloud/translations/it.json
@@ -221,7 +221,8 @@
           "idle": "In attesa",
           "searching_zone": "Ricerca zona",
           "starting": "Partenza",
-          "zoning": "Apprendimento zone"
+          "zoning": "Apprendimento zone",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} sta apprendendo una zona",
       "is_searching_zone": "{entity_name} sta cercando una zona",
       "is_idle": "{entity_name} è in attesa",
-      "is_escaped_digital_fence": "{entity_name} è fuori dal recinto digitale"
+      "is_escaped_digital_fence": "{entity_name} è fuori dal recinto digitale",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} ha iniziato a tagliare il prato",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} ha iniziato l'apprendimento di una zona",
       "searching_zone": "{entity_name} ha iniziato a cercare una zona",
       "idle": "{entity_name} è tornato in attesa",
-      "escaped_digital_fence": "{entity_name} è uscito dal recinto digitale"
+      "escaped_digital_fence": "{entity_name} è uscito dal recinto digitale",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/nb.json
+++ b/custom_components/landroid_cloud/translations/nb.json
@@ -221,7 +221,8 @@
           "idle": "Venter",
           "searching_zone": "Søker etter sone",
           "starting": "Starter",
-          "zoning": "Sonetrening"
+          "zoning": "Sonetrening",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} trener på soner",
       "is_searching_zone": "{entity_name} søker etter en sone",
       "is_idle": "{entity_name} venter",
-      "is_escaped_digital_fence": "{entity_name} er utenfor det digitale gjerdet"
+      "is_escaped_digital_fence": "{entity_name} er utenfor det digitale gjerdet",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} begynte å klippe",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} begynte sonetreningen",
       "searching_zone": "{entity_name} begynte å søke etter en sone",
       "idle": "{entity_name} gikk til ventemodus",
-      "escaped_digital_fence": "{entity_name} kom utenfor det digitale gjerdet"
+      "escaped_digital_fence": "{entity_name} kom utenfor det digitale gjerdet",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/nl.json
+++ b/custom_components/landroid_cloud/translations/nl.json
@@ -221,7 +221,8 @@
           "idle": "Inactief",
           "searching_zone": "Zone zoeken",
           "starting": "Starten",
-          "zoning": "Zone-inleren"
+          "zoning": "Zone-inleren",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} leert een zone in",
       "is_searching_zone": "{entity_name} zoekt naar een zone",
       "is_idle": "{entity_name} is inactief",
-      "is_escaped_digital_fence": "{entity_name} staat buiten het digitale hek"
+      "is_escaped_digital_fence": "{entity_name} staat buiten het digitale hek",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} is begonnen met maaien",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} begon met het inleren van een zone",
       "searching_zone": "{entity_name} begon naar een zone te zoeken",
       "idle": "{entity_name} werd inactief",
-      "escaped_digital_fence": "{entity_name} ging buiten het digitale hek"
+      "escaped_digital_fence": "{entity_name} ging buiten het digitale hek",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/no.json
+++ b/custom_components/landroid_cloud/translations/no.json
@@ -221,7 +221,8 @@
           "idle": "Venter",
           "searching_zone": "Søker etter sone",
           "starting": "Starter",
-          "zoning": "Sonetrening"
+          "zoning": "Sonetrening",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} trener på soner",
       "is_searching_zone": "{entity_name} søker etter en sone",
       "is_idle": "{entity_name} venter",
-      "is_escaped_digital_fence": "{entity_name} er utenfor det digitale gjerdet"
+      "is_escaped_digital_fence": "{entity_name} er utenfor det digitale gjerdet",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} begynte å klippe",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} begynte sonetreningen",
       "searching_zone": "{entity_name} begynte å søke etter en sone",
       "idle": "{entity_name} gikk til ventemodus",
-      "escaped_digital_fence": "{entity_name} kom utenfor det digitale gjerdet"
+      "escaped_digital_fence": "{entity_name} kom utenfor det digitale gjerdet",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/pl.json
+++ b/custom_components/landroid_cloud/translations/pl.json
@@ -221,7 +221,8 @@
           "idle": "Bezczynny",
           "searching_zone": "Szukanie strefy",
           "starting": "Rozpoczynanie",
-          "zoning": "Przyuczanie strefy"
+          "zoning": "Przyuczanie strefy",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} uczy się strefy",
       "is_searching_zone": "{entity_name} szuka strefy",
       "is_idle": "{entity_name} jest bezczynna",
-      "is_escaped_digital_fence": "{entity_name} znajduje się poza cyfrowym ogrodzeniem"
+      "is_escaped_digital_fence": "{entity_name} znajduje się poza cyfrowym ogrodzeniem",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} rozpoczęła koszenie",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} rozpoczęła naukę strefy",
       "searching_zone": "{entity_name} rozpoczęła szukanie strefy",
       "idle": "{entity_name} przeszła w stan bezczynności",
-      "escaped_digital_fence": "{entity_name} opuściła cyfrowe ogrodzenie"
+      "escaped_digital_fence": "{entity_name} opuściła cyfrowe ogrodzenie",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/ro.json
+++ b/custom_components/landroid_cloud/translations/ro.json
@@ -221,7 +221,8 @@
           "idle": "În așteptare",
           "searching_zone": "În căutarea zonei",
           "starting": "Pornire",
-          "zoning": "Antrenament pentru zonă"
+          "zoning": "Antrenament pentru zonă",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} învață o zonă",
       "is_searching_zone": "{entity_name} caută o zonă",
       "is_idle": "{entity_name} este în așteptare",
-      "is_escaped_digital_fence": "{entity_name} este în afara gardului digital"
+      "is_escaped_digital_fence": "{entity_name} este în afara gardului digital",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} a început să tundă",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} a început antrenamentul pentru zonă",
       "searching_zone": "{entity_name} a început să caute o zonă",
       "idle": "{entity_name} a intrat în așteptare",
-      "escaped_digital_fence": "{entity_name} a ieșit din gardul digital"
+      "escaped_digital_fence": "{entity_name} a ieșit din gardul digital",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/ru.json
+++ b/custom_components/landroid_cloud/translations/ru.json
@@ -221,7 +221,8 @@
           "idle": "Ожидание",
           "searching_zone": "Поиск зоны",
           "starting": "Запуск",
-          "zoning": "Обучение зоне"
+          "zoning": "Обучение зоне",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} обучает зону",
       "is_searching_zone": "{entity_name} ищет зону",
       "is_idle": "{entity_name} находится в ожидании",
-      "is_escaped_digital_fence": "{entity_name} находится за пределами цифрового ограждения"
+      "is_escaped_digital_fence": "{entity_name} находится за пределами цифрового ограждения",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} начал косить",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} начал обучение зоны",
       "searching_zone": "{entity_name} начал поиск зоны",
       "idle": "{entity_name} перешёл в режим ожидания",
-      "escaped_digital_fence": "{entity_name} вышел за пределы цифрового ограждения"
+      "escaped_digital_fence": "{entity_name} вышел за пределы цифрового ограждения",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"

--- a/custom_components/landroid_cloud/translations/sv.json
+++ b/custom_components/landroid_cloud/translations/sv.json
@@ -221,7 +221,8 @@
           "idle": "Inaktiv",
           "searching_zone": "Söker efter zon",
           "starting": "Startar",
-          "zoning": "Zonträning"
+          "zoning": "Zonträning",
+          "rain_delayed": "Rain delay"
         }
       }
     }
@@ -242,7 +243,8 @@
       "is_zoning": "{entity_name} tränar en zon",
       "is_searching_zone": "{entity_name} söker efter en zon",
       "is_idle": "{entity_name} är inaktiv",
-      "is_escaped_digital_fence": "{entity_name} är utanför det digitala staketet"
+      "is_escaped_digital_fence": "{entity_name} är utanför det digitala staketet",
+      "is_rain_delayed": "{entity_name} is in rain delay"
     },
     "trigger_type": {
       "mowing": "{entity_name} började klippa",
@@ -254,7 +256,8 @@
       "zoning": "{entity_name} började zonträningen",
       "searching_zone": "{entity_name} började söka efter en zon",
       "idle": "{entity_name} blev inaktiv",
-      "escaped_digital_fence": "{entity_name} kom utanför det digitala staketet"
+      "escaped_digital_fence": "{entity_name} kom utanför det digitala staketet",
+      "rain_delayed": "{entity_name} entered rain delay"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"


### PR DESCRIPTION
## Summary
Adds the `rain_delayed` mower state and exposes it consistently in entity state handling, device conditions, device triggers, and translations.

Fixes #1164

## Testing
- `git status` checked before commit
- `.venv/bin/python -m ruff format custom_components/landroid_cloud/const.py custom_components/landroid_cloud/lawn_mower.py custom_components/landroid_cloud/device_condition.py custom_components/landroid_cloud/device_trigger.py`
- `.venv/bin/python -m ruff check custom_components/landroid_cloud/const.py custom_components/landroid_cloud/lawn_mower.py custom_components/landroid_cloud/device_condition.py custom_components/landroid_cloud/device_trigger.py`
- Test execution could not run on the dev server because the repository venv does not currently include `pytest` or `homeassistant`

## Known limitations
The local dev environment on the server is missing the dependencies required to execute the test suite.

## Configuration changes
No configuration changes required.

## Proposed semver label
patch
