### PR TITLE
Fix zone selector so Kress devices show the right zone

### DIFF
--- a/custom_components/landroid_cloud/select.py
+++ b/custom_components/landroid_cloud/select.py
@@ -13,11 +13,25 @@ from .commands import async_run_cloud_command
 from .entity import LandroidBaseEntity
 
 
+def _configured_legacy_zone_options(device) -> list[str]:
+    """Return configured legacy zone numbers when start points are known."""
+    starting_points = device.zone.get("starting_point", [])
+    return [
+        str(index + 1)
+        for index, start in enumerate(starting_points)
+        if isinstance(start, int) and start > 0
+    ]
+
+
 def _zone_options(device) -> list[str]:
     """Return available zone options for legacy and RTK devices."""
     zone_ids = device.zone.get("ids", [])
     if zone_ids:
         return [str(zone_id) for zone_id in zone_ids]
+
+    configured_zones = _configured_legacy_zone_options(device)
+    if configured_zones:
+        return configured_zones
 
     starting_points = device.zone.get("starting_point", [])
     zone_count = len(starting_points)
@@ -35,8 +49,23 @@ def _current_zone_option(device) -> str | None:
             return str(int(current))
         return None
 
+    options = _zone_options(device)
+    current = device.zone.get("current")
+    if isinstance(current, int):
+        current_option = str(current)
+        if current_option in options:
+            return current_option
+
+        current_option = str(current + 1)
+        if current_option in options:
+            return current_option
+
     index = device.zone.get("index", 0)
-    return str(int(index) + 1)
+    current_option = str(int(index) + 1)
+    if current_option in options:
+        return current_option
+
+    return None
 
 
 async def async_setup_entry(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -25,3 +25,21 @@ def test_current_zone_option_uses_rtk_current_zone() -> None:
     device = SimpleNamespace(zone={"ids": [1, 2, 4, 5], "current": 4, "index": 0})
 
     assert _current_zone_option(device) == "4"
+
+
+def test_zone_options_only_include_configured_legacy_zones() -> None:
+    """Legacy devices should only expose zones with configured start points."""
+    device = SimpleNamespace(
+        zone={"ids": [], "starting_point": [1, 7, 0, 0], "current": 1, "index": 3}
+    )
+
+    assert _zone_options(device) == ["1", "2"]
+
+
+def test_current_zone_option_prefers_reported_legacy_zone() -> None:
+    """Legacy devices should display the reported current zone before fallback index."""
+    device = SimpleNamespace(
+        zone={"ids": [], "starting_point": [1, 7, 0, 0], "current": 1, "index": 3}
+    )
+
+    assert _current_zone_option(device) == "1"


### PR DESCRIPTION
## Summary
Fix the zone selector for legacy/Kress devices so it only shows configured zones and displays the reported current zone instead of deriving it from the internal zone index.

## Changes
The selector now builds legacy zone options from non-zero `starting_point` entries, which avoids exposing zones that are not configured. It also prefers `zone.current` for the selected value and only falls back to the old index-based behavior when needed.

Tests now cover the payload pattern from the reported Kress issue, where two zones are configured but the old UI showed zone 4.

## Testing
- git status: clean on `fix/zone-selector-display-1163` after commit
- ruff format custom_components/landroid_cloud/select.py tests/test_select.py
- ruff check custom_components/landroid_cloud/select.py tests/test_select.py
- pytest tests/test_select.py

## Known limitations
This PR only fixes the displayed values in the existing select entity. It does not convert zone display into a read-only entity.

## Configuration changes
None.

## Semver
Proposed semver label: `patch`.

Fixes #1163
