### PR TITLE
Bump pyworxcloud to 6.2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,12 +134,13 @@ feature/<name> - for introducing new features
 fix/<name> - fixing bugs
 enhancement/<name> - for code or stability enhancements
 chore/<name> - for repository and code chores
+dependency/<name> - for dependency version updates
 translation/<name> - for translation purposes
 ```
 
 All new branches MUST be based on `master`, unless the user explicitly instructs otherwise.
 
-All code changes MUST start from a dedicated `feature/...`, `fix/...`, or `chore/...` branch.
+All code changes MUST start from a dedicated `feature/...`, `fix/...`, `chore/...`, `translation/...`, `enhancement/...` or `dependency/...` branch.
 
 The agent must NEVER push directly to `master` and NEVER merge directly to `master` unless the user explicitly asks for it in the current session.
 
@@ -157,7 +158,7 @@ Each PR must include:
 - Known limitations
 - Any required configuration changes
 - The correct semver label (`patch`, `minor`, or `major`) before merge
-- A proposed semver label that is explicitly verified with the user before the label is set or changed
+- A proposed semver label that is explicitly verified with the user before the label is set or changed - all other semver labels MUST be removed before merge
 - If the PR resolves an issue, include the text `Fixes #<issue-id>`
 - A shout, descriptive and human readable title
 

--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -9,7 +9,7 @@
     "issue_tracker": "https://github.com/MTrab/landroid_cloud/issues",
     "loggers": ["pyworxcloud"],
     "requirements": [
-        "pyworxcloud@git+https://github.com/mtrab/pyworxcloud.git@master"
+        "pyworxcloud==6.2.0"
     ],
     "version": "7.0.0b3"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytest-asyncio==1.3.0
 pytest-cov==7.1.0
 pip>=21.0,<26.1
 ruff==0.15.8
-pyworxcloud==6.1.1
+pyworxcloud==6.2.0


### PR DESCRIPTION
## Summary
This PR updates the integration to use the released `pyworxcloud==6.2.0` package in both the development requirements and the integration manifest.

It also updates `AGENTS.md` so `dependency/...` is an explicit allowed branch type and clarifies that non-selected semver labels must be removed before merge.

## Test strategy
Automated validation run locally:
- `ruff format custom_components tests`
- `ruff check custom_components tests`

No additional targeted tests were run because this PR only changes dependency/version references and repository workflow guidance.

## Known limitations
This PR does not include runtime verification against the new pyworxcloud release beyond the version bump itself.
The semver label has not been set yet.

## Configuration changes
`custom_components/landroid_cloud/manifest.json` now depends on the released PyPI package `pyworxcloud==6.2.0` instead of the temporary git `master` pin.

## Proposed semver label
Proposed label: `patch` (pending verification before setting).
