### PR TITLE
Fix rain delay automation placeholder mismatch

### DIFF
--- a/custom_components/landroid_cloud/translations/en.json
+++ b/custom_components/landroid_cloud/translations/en.json
@@ -264,7 +264,7 @@
       "is_searching_zone": "{entity_name} is searching for a zone",
       "is_idle": "{entity_name} is idle",
       "is_escaped_digital_fence": "{entity_name} is outside the digital fence",
-      "is_rain_delayed": "Mower is rain delayed"
+      "is_rain_delayed": "{entity_name} is rain delayed"
     },
     "trigger_type": {
       "mowing": "{entity_name} started mowing",
@@ -277,7 +277,7 @@
       "searching_zone": "{entity_name} started searching for a zone",
       "idle": "{entity_name} became idle",
       "escaped_digital_fence": "{entity_name} escaped the digital fence",
-      "rain_delayed": "Rain delayed"
+      "rain_delayed": "{entity_name} became rain delayed"
     },
     "extra_fields": {
       "for": "[%key:common::device_automation::extra_fields::for%]"


### PR DESCRIPTION
## Description\nThis fixes the English rain-delay device automation strings so their placeholders match the localized translations.\n\n## Test strategy\nValidated the updated translation file as JSON locally.\n\n## Known limitations\nThis only adjusts translation placeholders and does not change runtime automation behavior.\n\n## Configuration changes\nNone.\n\n## Semver\npatch\n