### PR TITLE
Disable off limits switches by default

### DIFF
--- a/custom_components/landroid_cloud/switch.py
+++ b/custom_components/landroid_cloud/switch.py
@@ -67,6 +67,7 @@ SWITCHES: tuple[LandroidSwitchDescription, ...] = (
         translation_key="off_limits",
         icon="mdi:border-none-variant",
         entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
         capability=DeviceCapability.OFF_LIMITS,
     ),
     LandroidSwitchDescription(
@@ -74,6 +75,7 @@ SWITCHES: tuple[LandroidSwitchDescription, ...] = (
         translation_key="off_limits_shortcut",
         icon="mdi:transit-detour",
         entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
         capability=DeviceCapability.OFF_LIMITS,
     ),
     LandroidSwitchDescription(


### PR DESCRIPTION
## Summary
This change disables the off-limits configuration switches by default so newly added entities do not appear enabled in the registry.

## Test strategy
- `ruff format custom_components/landroid_cloud/switch.py tests/test_switch.py`
- `ruff check custom_components/landroid_cloud/switch.py tests/test_switch.py`
- `pytest -q tests/test_switch.py`

## Known limitations
This only changes the default entity registry state for the relevant switch entities. Existing entities already created in Home Assistant keep their current registry state.

## Configuration changes
No configuration changes are required.

## Semver
Proposed semver label: `patch` (not applied yet)