### PR TITLE
Align select platform layout with the other entity platforms

### DIFF
--- a/custom_components/landroid_cloud/select.py
+++ b/custom_components/landroid_cloud/select.py
@@ -92,12 +92,20 @@ def _auto_schedule_setting_option(device, key: str) -> str | None:
 
 @dataclass(frozen=True, kw_only=True)
 class LandroidSelectDescription(SelectEntityDescription):
-    """Description for auto-schedule selects."""
+    """Description for Landroid selects."""
 
     options: tuple[str, ...]
 
 
-AUTO_SCHEDULE_SELECTS: Final[tuple[LandroidSelectDescription, ...]] = (
+SELECTS: Final[tuple[LandroidSelectDescription, ...]] = (
+    LandroidSelectDescription(
+        key="zone",
+        translation_key="zone",
+        options=(),
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        icon="mdi:map-clock",
+    ),
     LandroidSelectDescription(
         key="auto_schedule_boost",
         translation_key="auto_schedule_boost",
@@ -135,22 +143,26 @@ async def async_setup_entry(
     entities: list[SelectEntity] = []
 
     for serial_number in coordinator.data:
-        entities.append(
-            LandroidZoneSelect(
-                coordinator=coordinator,
-                config_entry=entry,
-                serial_number=serial_number,
+        for description in SELECTS:
+            if description.key == "zone":
+                entities.append(
+                    LandroidZoneSelect(
+                        coordinator=coordinator,
+                        config_entry=entry,
+                        serial_number=serial_number,
+                        description=description,
+                    )
+                )
+                continue
+
+            entities.append(
+                LandroidAutoScheduleSelect(
+                    coordinator=coordinator,
+                    config_entry=entry,
+                    serial_number=serial_number,
+                    description=description,
+                )
             )
-        )
-        entities.extend(
-            LandroidAutoScheduleSelect(
-                coordinator=coordinator,
-                config_entry=entry,
-                serial_number=serial_number,
-                description=description,
-            )
-            for description in AUTO_SCHEDULE_SELECTS
-        )
 
     async_add_entities(entities)
 
@@ -158,19 +170,21 @@ async def async_setup_entry(
 class LandroidZoneSelect(LandroidBaseEntity, SelectEntity):
     """Representation of zone selection."""
 
-    _attr_icon = "mdi:map-clock"
-    _attr_entity_category = EntityCategory.CONFIG
+    entity_description: LandroidSelectDescription
     _attr_requires_online = True
-    _attr_translation_key = "zone"
 
-    def __init__(self, coordinator, config_entry, serial_number: str) -> None:
+    def __init__(
+        self,
+        coordinator,
+        config_entry,
+        serial_number: str,
+        description: LandroidSelectDescription,
+    ) -> None:
         """Initialize select entity."""
-        super().__init__(coordinator, config_entry, serial_number, "zone")
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Disable zone select by default."""
-        return False
+        self.entity_description = description
+        super().__init__(
+            coordinator, config_entry, serial_number, self.entity_description.key
+        )
 
     @property
     def options(self) -> list[str]:

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -2,17 +2,16 @@
 
 from types import SimpleNamespace
 
-from custom_components.landroid_cloud.select import AUTO_SCHEDULE_SELECTS
 from custom_components.landroid_cloud.select import LandroidAutoScheduleSelect
-from custom_components.landroid_cloud.select import LandroidZoneSelect
+from custom_components.landroid_cloud.select import SELECTS
 from custom_components.landroid_cloud.select import _current_zone_option, _zone_options
 
 
 def test_zone_select_is_disabled_by_default() -> None:
     """Zone select should be disabled by default."""
-    entity = object.__new__(LandroidZoneSelect)
+    descriptions = {description.key: description for description in SELECTS}
 
-    assert entity.entity_registry_enabled_default is False
+    assert descriptions["zone"].entity_registry_enabled_default is False
 
 
 def test_zone_options_use_rtk_zone_ids_when_available() -> None:
@@ -31,9 +30,7 @@ def test_current_zone_option_uses_rtk_current_zone() -> None:
 
 def test_auto_schedule_selects_use_pyworxcloud_valid_options() -> None:
     """Auto-schedule selects should only expose pyworxcloud-supported values."""
-    descriptions = {
-        description.key: description for description in AUTO_SCHEDULE_SELECTS
-    }
+    descriptions = {description.key: description for description in SELECTS}
 
     assert descriptions["auto_schedule_boost"].options == ("0", "1", "2")
     assert descriptions["auto_schedule_grass_type"].options == (
@@ -54,9 +51,7 @@ def test_auto_schedule_selects_use_pyworxcloud_valid_options() -> None:
 
 def test_auto_schedule_selects_have_distinct_icons() -> None:
     """Auto-schedule selects should expose meaningful icons in the UI."""
-    descriptions = {
-        description.key: description for description in AUTO_SCHEDULE_SELECTS
-    }
+    descriptions = {description.key: description for description in SELECTS}
 
     assert descriptions["auto_schedule_boost"].icon == "mdi:speedometer"
     assert descriptions["auto_schedule_grass_type"].icon == "mdi:grass"


### PR DESCRIPTION
## Summary
This change refactors the select platform so all select descriptions live in one shared tuple and the setup flow matches the layout used by the other entity platforms.

## Test strategy
- `ruff format custom_components/landroid_cloud/select.py tests/test_select.py`
- `ruff check custom_components/landroid_cloud/select.py tests/test_select.py`
- `pytest -q tests/test_select.py`

## Known limitations
This is a structural cleanup only. The zone select still uses its dedicated entity class because its behavior differs from the auto-schedule selects.

## Configuration changes
No configuration changes are required.

## Semver
Proposed semver label: `patch` (not applied yet)