### PR TITLE
Bump pyworxcloud to 6.3.0

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -13,7 +13,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud@git+https://github.com/MTrab/pyworxcloud.git@master"
+        "pyworxcloud==6.3.0"
     ],
     "version": "7.0.0b4"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytest-asyncio==1.3.0
 pytest-cov==7.1.0
 pip>=21.0,<26.1
 ruff==0.15.8
-pyworxcloud==6.2.0
+pyworxcloud==6.3.0


### PR DESCRIPTION
## Description
Update the dependency pins for pyworxcloud to 6.3.0 in both manifest.json and requirements.txt so the integration tracks the latest PyPI release.

## Testing
- ruff check custom_components tests

## Known limitations
- none

## Configuration changes
- none

## Semver label
- patch
