### PR TITLE
Keep update, charging, and battery entities unavailable while offline

### DIFF
--- a/custom_components/landroid_cloud/binary_sensor.py
+++ b/custom_components/landroid_cloud/binary_sensor.py
@@ -21,6 +21,8 @@ from .entity import LandroidBaseEntity
 class LandroidBinarySensorDescription(BinarySensorEntityDescription):
     """Description for Landroid binary sensors."""
 
+    requires_online: bool = False
+
 
 BINARY_SENSORS: tuple[LandroidBinarySensorDescription, ...] = (
     LandroidBinarySensorDescription(
@@ -35,6 +37,7 @@ BINARY_SENSORS: tuple[LandroidBinarySensorDescription, ...] = (
         translation_key="charging",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         entity_category=EntityCategory.DIAGNOSTIC,
+        requires_online=True,
     ),
 )
 
@@ -76,6 +79,7 @@ class LandroidBinarySensor(LandroidBaseEntity, BinarySensorEntity):
     ) -> None:
         """Initialize binary sensor entity."""
         self.entity_description = description
+        self._attr_requires_online = description.requires_online
         super().__init__(
             coordinator, config_entry, serial_number, self.entity_description.key
         )

--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -41,6 +41,7 @@ class LandroidSensorDescription(SensorEntityDescription):
     """Description for Landroid sensors."""
 
     requires_auto_schedule: bool = False
+    requires_online: bool = False
 
 
 def _battery_charging_attribute(device) -> dict[str, bool] | None:
@@ -351,6 +352,7 @@ SENSORS: tuple[LandroidSensorDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
+        requires_online=True,
     ),
     LandroidSensorDescription(
         key="error",
@@ -568,6 +570,7 @@ class LandroidSensor(LandroidBaseEntity, SensorEntity):
         """Initialize sensor entity."""
         self.entity_description = description
         self._attr_requires_auto_schedule = description.requires_auto_schedule
+        self._attr_requires_online = description.requires_online
         super().__init__(
             coordinator, config_entry, serial_number, self.entity_description.key
         )

--- a/custom_components/landroid_cloud/update.py
+++ b/custom_components/landroid_cloud/update.py
@@ -193,6 +193,7 @@ class LandroidFirmwareUpdateEntity(LandroidBaseEntity, UpdateEntity):
     """Representation of a Landroid firmware update entity."""
 
     entity_description: LandroidUpdateDescription
+    _attr_requires_online = True
     _attr_supported_features = (
         UpdateEntityFeature.INSTALL | UpdateEntityFeature.RELEASE_NOTES
     )

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,8 +1,13 @@
 """Tests for Landroid binary sensors."""
 
+from types import SimpleNamespace
+
 from homeassistant.helpers.entity import EntityCategory
 
-from custom_components.landroid_cloud.binary_sensor import BINARY_SENSORS
+from custom_components.landroid_cloud.binary_sensor import (
+    BINARY_SENSORS,
+    LandroidBinarySensor,
+)
 
 
 def test_rain_sensor_and_charging_are_diagnostic_entities() -> None:
@@ -33,3 +38,19 @@ def test_charging_is_enabled_by_default_but_rain_sensor_is_not() -> None:
 
     assert rain_sensor.entity_registry_enabled_default is False
     assert charging.entity_registry_enabled_default is True
+
+
+def test_charging_binary_sensor_is_unavailable_when_mower_is_offline() -> None:
+    """Charging binary sensor should be unavailable while the mower is offline."""
+    entity = object.__new__(LandroidBinarySensor)
+    entity.entity_description = next(
+        description for description in BINARY_SENSORS if description.key == "charging"
+    )
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data={"serial": SimpleNamespace(online=False, battery={"charging": True})},
+    )
+    entity._serial_number = "serial"
+    entity._attr_requires_online = entity.entity_description.requires_online
+
+    assert entity.available is False

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -561,6 +561,25 @@ def test_daily_progress_sensor_stays_available_with_zero() -> None:
     assert entity.available is True
 
 
+def test_battery_sensor_is_unavailable_when_mower_is_offline() -> None:
+    """Battery sensor should be unavailable while the mower is offline."""
+    entity = object.__new__(LandroidSensor)
+    entity.entity_description = next(
+        description for description in SENSORS if description.key == "battery"
+    )
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data={"serial": SimpleNamespace(online=False, battery={"percent": 87})},
+    )
+    entity._serial_number = "serial"
+    entity._attr_requires_auto_schedule = (
+        entity.entity_description.requires_auto_schedule
+    )
+    entity._attr_requires_online = entity.entity_description.requires_online
+
+    assert entity.available is False
+
+
 def test_battery_cycle_value_returns_integer() -> None:
     """Battery cycle values should be exposed when present."""
     device = SimpleNamespace(battery={"cycles": {"total": 3014, "current": 14}})

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -92,6 +92,14 @@ def test_update_entity_supports_install_and_release_notes() -> None:
     )
 
 
+def test_update_entity_is_unavailable_when_mower_is_offline() -> None:
+    """Firmware update entity should be unavailable while the mower is offline."""
+    entity = _make_entity()
+    entity.coordinator.data["serial"].online = False
+
+    assert entity.available is False
+
+
 def test_release_notes_markdown_includes_product_and_head_sections() -> None:
     """Release notes should include both product and head changelogs."""
     notes = _release_notes_markdown(


### PR DESCRIPTION
## Description
This change makes the firmware update entity unavailable when the mower is offline, matching the existing availability behavior for other online-dependent entities.

It also applies the same online requirement to the charging binary sensor and battery sensor, so battery-related entities are consistently unavailable while the mower is disconnected.

## Test strategy
Validated locally with `ruff format`, `ruff check --fix`, and `python -m pytest -q tests/test_binary_sensor.py tests/test_sensor.py tests/test_update.py tests/test_entity.py`.

## Known limitations
This change only adjusts entity availability based on the existing `device.online` state reported by pyworxcloud. It does not change how connectivity is detected.

## Configuration changes
No configuration changes are required.

## Semver
Proposed semver label: `patch` (not applied yet; awaiting verification before any semver label is set).