### PR TITLE
Fix typo in party mode function call

### DIFF
--- a/custom_components/landroid_cloud/switch.py
+++ b/custom_components/landroid_cloud/switch.py
@@ -199,7 +199,7 @@ class LandroidSwitch(LandroidBaseEntity, SwitchEntity):
             )
         elif self.entity_description.key == "party_mode":
             await async_run_cloud_command(
-                lambda: self.coordinator.cloud.set_partymode(serial_number, state)
+                lambda: self.coordinator.cloud.set_party_mode(serial_number, state)
             )
         elif self.entity_description.key == "firmware_auto_update":
             await async_run_cloud_command(


### PR DESCRIPTION
`patch`

replace "partymode" by" "Party_mode" and the action est OK in V7.0.0b4

