### PR TITLE
Bring back raw device data in diagnostics

### DIFF
--- a/custom_components/landroid_cloud/diagnostics.py
+++ b/custom_components/landroid_cloud/diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date, datetime
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -16,8 +17,58 @@ TO_REDACT = {
     "access_token",
     "refresh_token",
     "user_id",
+    "mqtt_topics",
     "mqtt_endpoint",
+    "mac",
+    "mac_address",
+    "uuid",
 }
+
+
+def _capabilities_value(device: Any) -> int | None:
+    """Return a stable integer representation of device capabilities."""
+    capabilities = getattr(device, "capabilities", None)
+    if capabilities is None:
+        return None
+
+    if isinstance(capabilities, int):
+        return capabilities
+
+    raw_int = getattr(capabilities, "__int__", None)
+    if isinstance(raw_int, int):
+        return raw_int
+    if callable(raw_int):
+        try:
+            return int(raw_int())
+        except TypeError, ValueError:
+            return None
+
+    try:
+        return int(capabilities)
+    except TypeError, ValueError:
+        return None
+
+
+def _jsonable(value: Any) -> Any:
+    """Convert diagnostics payloads to JSON-friendly structures."""
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+
+    if isinstance(value, list | tuple | set):
+        return [_jsonable(item) for item in value]
+
+    if isinstance(value, datetime | date):
+        return value.isoformat()
+
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+
+    if hasattr(value, "as_dict"):
+        as_dict = value.as_dict()
+        if isinstance(as_dict, dict):
+            return _jsonable(as_dict)
+
+    return str(value)
 
 
 async def async_get_config_entry_diagnostics(
@@ -33,13 +84,18 @@ async def async_get_config_entry_diagnostics(
         devices[serial_number] = {
             "name": getattr(device, "name", None),
             "model": getattr(device, "model", None),
-            "firmware": dict(getattr(device, "firmware", {})),
+            "firmware": _jsonable(dict(getattr(device, "firmware", {}))),
             "online": getattr(device, "online", None),
-            "capabilities": int(getattr(device.capabilities, "__int__", 0)),
-            "status": dict(getattr(device, "status", {})),
-            "error": dict(getattr(device, "error", {})),
-            "zone": dict(getattr(device, "zone", {})),
-            "schedules": dict(getattr(device, "schedules", {})),
+            "capabilities": _capabilities_value(device),
+            "status": _jsonable(dict(getattr(device, "status", {}))),
+            "error": _jsonable(dict(getattr(device, "error", {}))),
+            "zone": _jsonable(dict(getattr(device, "zone", {}))),
+            "schedules": _jsonable(dict(getattr(device, "schedules", {}))),
+            "last_status": _jsonable(getattr(device, "last_status", None)),
+            "raw_cfg": _jsonable(getattr(device, "raw_cfg", None)),
+            "raw_dat": _jsonable(getattr(device, "raw_dat", None)),
+            "json_data": _jsonable(getattr(device, "json_data", None)),
+            "mower": _jsonable(getattr(device, "mower", None)),
         }
 
     return async_redact_data(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,106 @@
+"""Tests for diagnostics payloads."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.landroid_cloud.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_include_raw_device_data_and_redact_secrets() -> None:
+    """Diagnostics should expose raw device payloads while redacting secrets."""
+    device = SimpleNamespace(
+        name="Garden",
+        model="WR147E",
+        firmware={"version": "3.32"},
+        online=True,
+        capabilities=0,
+        status={"id": 7},
+        error={"id": 0},
+        zone={"current": 1},
+        schedules={"active": True},
+        last_status={
+            "timestamp": datetime(2026, 4, 10, 12, 30, tzinfo=UTC),
+            "payload": {
+                "cfg": {"sn": "SN123", "modules": {"US": {"enabled": 1}}},
+                "dat": {"mac": "AA:BB:CC:DD:EE:FF", "uuid": "uuid-123"},
+            },
+        },
+        raw_cfg={"sn": "SN123", "mqtt_topics": {"command_in": "topic/in"}},
+        raw_dat={"mac": "AA:BB:CC:DD:EE:FF", "uuid": "uuid-123", "rsi": -67},
+        json_data={"cfg": {"sn": "SN123"}, "dat": {"mac": "AA:BB:CC:DD:EE:FF"}},
+        mower={
+            "serial_number": "SN123",
+            "mqtt_endpoint": "mqtt.example.invalid",
+            "user_id": "user-123",
+            "last_status": {"payload": {"cfg": {"sn": "SN123"}}},
+        },
+    )
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(
+            coordinator=SimpleNamespace(data={"SN123": device})
+        ),
+        as_dict=lambda: {
+            "data": {
+                "email": "user@example.com",
+                "password": "super-secret",
+                "access_token": "access-123",
+                "refresh_token": "refresh-123",
+            }
+        },
+    )
+
+    result = await async_get_config_entry_diagnostics(SimpleNamespace(), entry)
+
+    assert result["entry"]["data"]["email"] == "**REDACTED**"
+    assert result["entry"]["data"]["password"] == "**REDACTED**"
+    assert result["entry"]["data"]["access_token"] == "**REDACTED**"
+    assert result["entry"]["data"]["refresh_token"] == "**REDACTED**"
+    assert result["devices"]["SN123"]["raw_cfg"]["sn"] == "SN123"
+    assert result["devices"]["SN123"]["raw_cfg"]["mqtt_topics"] == "**REDACTED**"
+    assert result["devices"]["SN123"]["raw_dat"]["rsi"] == -67
+    assert result["devices"]["SN123"]["raw_dat"]["mac"] == "**REDACTED**"
+    assert result["devices"]["SN123"]["raw_dat"]["uuid"] == "**REDACTED**"
+    assert result["devices"]["SN123"]["json_data"]["dat"]["mac"] == "**REDACTED**"
+    assert result["devices"]["SN123"]["mower"]["mqtt_endpoint"] == "**REDACTED**"
+    assert result["devices"]["SN123"]["mower"]["user_id"] == "**REDACTED**"
+    assert result["devices"]["SN123"]["capabilities"] == 0
+    assert result["devices"]["SN123"]["last_status"]["timestamp"] == (
+        "2026-04-10T12:30:00+00:00"
+    )
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_handle_capability_objects() -> None:
+    """Diagnostics should serialize pyworxcloud Capability objects safely."""
+
+    class _Capability:
+        __int__ = 12
+
+    device = SimpleNamespace(
+        name="Garden",
+        model="WR147E",
+        firmware={},
+        online=True,
+        capabilities=_Capability(),
+        status={},
+        error={},
+        zone={},
+        schedules={},
+    )
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(
+            coordinator=SimpleNamespace(data={"SN123": device})
+        ),
+        as_dict=lambda: {"data": {}},
+    )
+
+    result = await async_get_config_entry_diagnostics(SimpleNamespace(), entry)
+
+    assert result["devices"]["SN123"]["capabilities"] == 12


### PR DESCRIPTION
## Summary
This restores the raw device payloads in diagnostics so v7 once again includes the underlying mower data needed for troubleshooting.

The diagnostics payload now includes `last_status`, `raw_cfg`, `raw_dat`, `json_data`, and the source `mower` data, while still redacting sensitive fields such as credentials, MQTT details, MAC addresses, and UUIDs. It also fixes capability serialization so `pyworxcloud` capability objects do not crash diagnostics generation.

## Test strategy
Automated validation only.

Commands run:
- `ruff format custom_components/landroid_cloud/diagnostics.py tests/test_diagnostics.py`
- `ruff check --fix custom_components/landroid_cloud/diagnostics.py tests/test_diagnostics.py`
- `pytest -q tests/test_diagnostics.py tests/test_config_migration.py tests/test_entity.py tests/test_sensor.py tests/test_binary_sensor.py`

## Known limitations
This change does not alter the underlying cloud payload contents; it only exposes more of the already-available device state through Home Assistant diagnostics.

## Configuration changes
None.

## Semver
Proposed semver label: `patch`.
Label not applied yet; awaiting explicit verification.
