### PR TITLE
Fix Kress legacy zone display so the UI shows the expected zone

### DIFF
--- a/custom_components/landroid_cloud/select.py
+++ b/custom_components/landroid_cloud/select.py
@@ -200,7 +200,7 @@ class LandroidZoneSelect(LandroidBaseEntity, SelectEntity):
         """Set selected zone."""
         if self.device.zone.get("ids", []):
             raise HomeAssistantError(
-                "Zone selection for RTK devices is not supported yet"
+                "Zone selection for RTK/Vision devices is not supported yet"
             )
         zone = int(option)
         serial_number = str(self.device.serial_number)

--- a/custom_components/landroid_cloud/select.py
+++ b/custom_components/landroid_cloud/select.py
@@ -66,11 +66,11 @@ def _current_zone_option(device) -> str | None:
     options = _zone_options(device)
     current = device.zone.get("current")
     if isinstance(current, int):
-        current_option = str(current)
+        current_option = str(current + 1)
         if current_option in options:
             return current_option
 
-        current_option = str(current + 1)
+        current_option = str(current)
         if current_option in options:
             return current_option
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -87,9 +87,18 @@ def test_zone_options_only_include_configured_legacy_zones() -> None:
 
 
 def test_current_zone_option_prefers_reported_legacy_zone() -> None:
-    """Legacy devices should display the reported current zone before fallback index."""
+    """Legacy devices should display the reported zone as a 1-based value."""
     device = SimpleNamespace(
         zone={"ids": [], "starting_point": [1, 7, 0, 0], "current": 1, "index": 3}
     )
 
-    assert _current_zone_option(device) == "1"
+    assert _current_zone_option(device) == "2"
+
+
+def test_current_zone_option_falls_back_to_raw_legacy_zone_when_needed() -> None:
+    """Legacy devices should still accept already 1-based current zones."""
+    device = SimpleNamespace(
+        zone={"ids": [], "starting_point": [1, 7, 0, 0], "current": 2, "index": 0}
+    )
+
+    assert _current_zone_option(device) == "2"


### PR DESCRIPTION
## Description
This adjusts the integration-layer zone display logic for legacy multi-zone mowers so the reported zone is shown as a 1-based user-facing value before falling back to the raw internal value.

This is aimed at Kress Mission devices where diagnostics indicate the cloud data uses zero-based legacy zone values, causing Home Assistant to show zone 1 while the Kress app shows zone 2.

Fixes #1181

## Test strategy
Automated validation only.

Ran:
- `ruff format custom_components/landroid_cloud/select.py tests/test_select.py`
- `ruff check custom_components/landroid_cloud/select.py tests/test_select.py`
- `pytest tests/test_select.py`

## Known limitations
This only adjusts the presentation logic in the Home Assistant integration. It does not change raw zone values in `pyworxcloud`, and it does not yet prove whether all Kress models use the same zero-based legacy zone representation.

## Required configuration changes
None.

## Proposed semver label
`patch`
