### PR TITLE
Change hub to device

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -6,7 +6,7 @@
     ],
     "config_flow": true,
     "documentation": "https://github.com/MTrab/landroid_cloud",
-    "integration_type": "hub",
+    "integration_type": "device",
     "iot_class": "cloud_push",
     "issue_tracker": "https://github.com/MTrab/landroid_cloud/issues",
     "loggers": [


### PR DESCRIPTION
## Change

Change `integration_type` from `hub` to `device`

## Reason

`hub` describes a hub device, like Phillips Hue, with multiple sub-devices.
`device` describes a single device pr. config entry, like ESPHome or lawnmowers.