### PR TITLE
Fix legacy zone selection for zero-based mowers

### DIFF
--- a/custom_components/landroid_cloud/select.py
+++ b/custom_components/landroid_cloud/select.py
@@ -82,6 +82,11 @@ def _current_zone_option(device) -> str | None:
     return None
 
 
+def _selected_legacy_zone_index(option: str) -> int:
+    """Translate a displayed legacy zone number to the mower's zero-based index."""
+    return int(option) - 1
+
+
 def _auto_schedule_setting_option(device, key: str) -> str | None:
     """Return one auto-schedule setting as a string option."""
     value = auto_schedule_settings(device).get(key)
@@ -202,7 +207,7 @@ class LandroidZoneSelect(LandroidBaseEntity, SelectEntity):
             raise HomeAssistantError(
                 "Zone selection for RTK/Vision devices is not supported yet"
             )
-        zone = int(option)
+        zone = _selected_legacy_zone_index(option)
         serial_number = str(self.device.serial_number)
         await async_run_cloud_command(
             lambda: self.coordinator.cloud.setzone(serial_number, zone)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,10 +1,14 @@
 """Tests for Landroid selects."""
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
+import pytest
 from custom_components.landroid_cloud.select import LandroidAutoScheduleSelect
+from custom_components.landroid_cloud.select import LandroidZoneSelect
 from custom_components.landroid_cloud.select import SELECTS
 from custom_components.landroid_cloud.select import _current_zone_option, _zone_options
+from custom_components.landroid_cloud import select as select_module
 
 
 def test_zone_select_is_disabled_by_default() -> None:
@@ -102,3 +106,30 @@ def test_current_zone_option_falls_back_to_raw_legacy_zone_when_needed() -> None
     )
 
     assert _current_zone_option(device) == "2"
+
+
+@pytest.mark.asyncio
+async def test_zone_select_converts_legacy_option_to_zero_based_index(
+    monkeypatch,
+) -> None:
+    """Legacy zone selection should send the zero-based zone index to pyworxcloud."""
+    entity = object.__new__(LandroidZoneSelect)
+    entity._serial_number = "serial"
+    entity.coordinator = SimpleNamespace(
+        cloud=SimpleNamespace(setzone=AsyncMock()),
+        data={
+            "serial": SimpleNamespace(
+                serial_number="serial",
+                zone={"ids": [], "starting_point": [1, 7, 0, 0]},
+            )
+        },
+    )
+
+    async def _run_command(command):
+        await command()
+
+    monkeypatch.setattr(select_module, "async_run_cloud_command", _run_command)
+
+    await entity.async_select_option("1")
+
+    entity.coordinator.cloud.setzone.assert_awaited_once_with("serial", 0)


### PR DESCRIPTION
## Summary
This change fixes legacy zone selection for mowers that expose zero-based internal zone indices. The Home Assistant select already presents those zones as user-facing 1-based values, so selecting zone 1 could incorrectly target the second configured zone.

The integration now maps the selected legacy zone option back to the mower's zero-based index before calling `pyworxcloud.setzone()`. A regression test covers the select path so the UI-to-cloud contract stays aligned.

Fixes #1208

## Test strategy
- `ruff format custom_components/landroid_cloud/select.py tests/test_select.py`
- `ruff check --fix custom_components/landroid_cloud/select.py tests/test_select.py`
- `pytest -q tests/test_select.py`

## Known limitations
RTK/Vision zone selection remains read-only in Home Assistant.

## Configuration changes
No configuration changes are required.

## Proposed semver label
`patch` (not applied yet)
