### PR TITLE
Stop False Unavailable Errors During Firmware Updates

### DIFF
--- a/custom_components/landroid_cloud/update.py
+++ b/custom_components/landroid_cloud/update.py
@@ -193,7 +193,7 @@ class LandroidFirmwareUpdateEntity(LandroidBaseEntity, UpdateEntity):
     """Representation of a Landroid firmware update entity."""
 
     entity_description: LandroidUpdateDescription
-    _attr_requires_online = True
+    _attr_requires_online = False
     _attr_supported_features = (
         UpdateEntityFeature.INSTALL | UpdateEntityFeature.RELEASE_NOTES
     )
@@ -308,6 +308,7 @@ class LandroidFirmwareUpdateEntity(LandroidBaseEntity, UpdateEntity):
     ) -> None:
         """Queue the firmware update."""
         del backup, kwargs
+        started_while_online = bool(getattr(self.device, "online", False))
         serial_number = str(self.device.serial_number)
         latest_version = self.latest_version
 
@@ -335,7 +336,15 @@ class LandroidFirmwareUpdateEntity(LandroidBaseEntity, UpdateEntity):
                 "No firmware update is currently available"
             ) from err
         except (NoConnectionError, OfflineError) as err:
-            raise HomeAssistantError("Mower is unavailable") from err
+            if started_while_online or self.in_progress:
+                _LOGGER.debug(
+                    "Ignoring transient firmware update availability error for %s (%s): %s",
+                    getattr(self.device, "name", serial_number),
+                    serial_number,
+                    err,
+                )
+            else:
+                raise HomeAssistantError("Mower is unavailable") from err
         except APIException as err:
             raise HomeAssistantError("Cloud command failed") from err
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from homeassistant.components.update import UpdateEntityFeature
 from homeassistant.exceptions import HomeAssistantError
+from pyworxcloud.exceptions import OfflineError
 
 from custom_components.landroid_cloud.update import (
     LandroidFirmwareUpdateEntity,
@@ -92,12 +93,12 @@ def test_update_entity_supports_install_and_release_notes() -> None:
     )
 
 
-def test_update_entity_is_unavailable_when_mower_is_offline() -> None:
-    """Firmware update entity should be unavailable while the mower is offline."""
+def test_update_entity_stays_available_when_mower_is_offline() -> None:
+    """Firmware update entity should stay available with cached metadata offline."""
     entity = _make_entity()
     entity.coordinator.data["serial"].online = False
 
-    assert entity.available is False
+    assert entity.available is True
 
 
 def test_release_notes_markdown_includes_product_and_head_sections() -> None:
@@ -249,4 +250,42 @@ async def test_async_install_surfaces_no_firmware_available() -> None:
     with pytest.raises(
         HomeAssistantError, match="No firmware update is currently available"
     ):
+        await entity.async_install(version=None, backup=False)
+
+
+@pytest.mark.asyncio
+async def test_async_install_ignores_offline_race_when_started_online() -> None:
+    """Transient offline races should not fail a queued install started online."""
+    listeners = Mock()
+    entity = _make_entity(
+        firmware={"version": "3.30"},
+        info={"latest_version": "3.31"},
+        start_firmware_upgrade=AsyncMock(
+            side_effect=OfflineError(
+                "The device is currently offline, no action was sent."
+            )
+        ),
+    )
+    entity.coordinator.async_update_listeners = listeners
+
+    await entity.async_install(version=None, backup=False)
+
+    listeners.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_async_install_surfaces_offline_when_started_offline() -> None:
+    """Offline installs should still fail when the mower was already offline."""
+    entity = _make_entity(
+        firmware={"version": "3.30"},
+        info={"latest_version": "3.31"},
+        start_firmware_upgrade=AsyncMock(
+            side_effect=OfflineError(
+                "The device is currently offline, no action was sent."
+            )
+        ),
+    )
+    entity.coordinator.data["serial"].online = False
+
+    with pytest.raises(HomeAssistantError, match="Mower is unavailable"):
         await entity.async_install(version=None, backup=False)


### PR DESCRIPTION
## Summary
This change prevents false `Mower is unavailable` errors when a firmware update is triggered while the mower is online and the OTA flow is already being queued.

## Changes
The firmware update entity now stays available even if the mower temporarily drops offline during the OTA process. The install flow also ignores transient offline or connection errors when the update was started while the mower was online, or when the update is already marked as queued.

Tests were updated to cover the new availability behavior, the transient offline race, and the existing real-offline failure path.

## Test strategy
- `ruff format custom_components/landroid_cloud/update.py tests/test_update.py`
- `ruff check --fix custom_components/landroid_cloud/update.py tests/test_update.py`
- `pytest -q tests/test_update.py`

## Known limitations
This does not change pyworxcloud's OTA semantics. It only avoids surfacing a false user-facing error from the integration when the update flow has already been accepted or is in progress.

## Configuration changes
None.

## Semver
Proposed semver label: `patch` (not applied yet; awaiting verification before labeling).
