### PR TITLE
Add `awsiotcrt` version `1.29.0` support in `pyworxcloud` module

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -13,7 +13,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud==6.3.4"
+        "pyworxcloud==6.3.5"
     ],
     "version": "7.0.3"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytest-asyncio==1.3.0
 pytest-cov==7.1.0
 pip>=21.0,<26.1
 ruff==0.15.10
-pyworxcloud==6.3.4
+pyworxcloud==6.3.5


### PR DESCRIPTION
Fixes #1229