### PR TITLE
Bring mower location back with native Home Assistant tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ Each mower creates one lawn mower entity with these actions:
 - Pause
 - Return to dock
 
+When the mower reports GPS coordinates, the lawn mower entity also keeps the legacy `latitude` and `longitude` attributes for backward compatibility with existing dashboards and automations.
+
+#### Device trackers
+
+Mowers that expose location support create one GPS device tracker entity.
+
+| Entity | Category | Default | Notes |
+| --- | --- | --- | --- |
+| Location | Standard | Disabled | Only created for mowers with location support |
+
+Notes:
+
+- The location tracker is disabled by default.
+- The entity may appear as unavailable until the mower reports a real GPS fix.
+
 #### Sensors
 
 | Entity | Category | Default |

--- a/custom_components/landroid_cloud/const.py
+++ b/custom_components/landroid_cloud/const.py
@@ -10,6 +10,7 @@ DOMAIN = "landroid_cloud"
 
 PLATFORMS: list[Platform] = [
     Platform.LAWN_MOWER,
+    Platform.DEVICE_TRACKER,
     Platform.SENSOR,
     Platform.SELECT,
     Platform.NUMBER,

--- a/custom_components/landroid_cloud/device_tracker.py
+++ b/custom_components/landroid_cloud/device_tracker.py
@@ -1,0 +1,63 @@
+"""Device tracker platform for Landroid Cloud."""
+
+from __future__ import annotations
+
+from homeassistant.components.device_tracker import SourceType
+from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .entity import LandroidBaseEntity, device_coordinates, device_supports_location
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Landroid Cloud device tracker entities."""
+    coordinator = entry.runtime_data.coordinator
+
+    async_add_entities(
+        LandroidCloudLocationEntity(coordinator, entry, serial_number)
+        for serial_number, device in coordinator.data.items()
+        if device_supports_location(device)
+    )
+
+
+class LandroidCloudLocationEntity(LandroidBaseEntity, TrackerEntity):
+    """Representation of a mower GPS location."""
+
+    _attr_source_type = SourceType.GPS
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator, config_entry, serial_number: str) -> None:
+        """Initialize location tracker entity."""
+        super().__init__(coordinator, config_entry, serial_number, "location")
+
+    @property
+    def name(self) -> str:
+        """Return entity name."""
+        return "Location"
+
+    @property
+    def available(self) -> bool:
+        """Return availability for the tracker."""
+        return super().available and device_coordinates(self.device) is not None
+
+    @property
+    def latitude(self) -> float | None:
+        """Return current latitude."""
+        if (coordinates := device_coordinates(self.device)) is None:
+            return None
+
+        return coordinates[0]
+
+    @property
+    def longitude(self) -> float | None:
+        """Return current longitude."""
+        if (coordinates := device_coordinates(self.device)) is None:
+            return None
+
+        return coordinates[1]

--- a/custom_components/landroid_cloud/entity.py
+++ b/custom_components/landroid_cloud/entity.py
@@ -98,6 +98,47 @@ class LandroidBaseEntity(CoordinatorEntity[LandroidCloudCoordinator]):
         return DeviceInfo(**info)
 
 
+def device_coordinates(device: DeviceHandler) -> tuple[float, float] | None:
+    """Return normalized GPS coordinates when available."""
+    gps = getattr(device, "gps", None)
+
+    if isinstance(gps, dict):
+        latitude = gps.get("latitude")
+        longitude = gps.get("longitude")
+    else:
+        latitude = getattr(gps, "latitude", None)
+        longitude = getattr(gps, "longitude", None)
+
+    if not isinstance(latitude, int | float) or not isinstance(longitude, int | float):
+        return None
+
+    return float(latitude), float(longitude)
+
+
+def device_location_attributes(device: DeviceHandler) -> dict[str, float] | None:
+    """Return legacy location attributes for entities that expose them."""
+    if (coordinates := device_coordinates(device)) is None:
+        return None
+
+    latitude, longitude = coordinates
+    return {"latitude": latitude, "longitude": longitude}
+
+
+def device_supports_location(device: DeviceHandler) -> bool:
+    """Return whether the mower exposes a GPS-capable 4G module."""
+    if device_coordinates(device) is not None:
+        return True
+
+    for modules in (
+        getattr(device, "module_config", None),
+        getattr(device, "module_status", None),
+    ):
+        if isinstance(modules, dict) and "4G" in modules:
+            return True
+
+    return False
+
+
 def auto_schedule(device: DeviceHandler) -> dict:
     """Return the normalized auto-schedule block when available."""
     schedules = getattr(device, "schedules", None)

--- a/custom_components/landroid_cloud/lawn_mower.py
+++ b/custom_components/landroid_cloud/lawn_mower.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers import entity_platform
 
 from .commands import async_run_cloud_command
-from .entity import LandroidBaseEntity
+from .entity import LandroidBaseEntity, device_location_attributes
 from . import services as integration_services
 from .const import (
     MOWER_STATE_EDGECUT,
@@ -136,6 +136,11 @@ class LandroidCloudMowerEntity(LandroidBaseEntity, LawnMowerEntity):
 
         status_id = int(getattr(self.device.status, "id", -1))
         return STATUS_ACTIVITY_MAP.get(status_id, LawnMowerActivity.ERROR)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, float] | None:
+        """Return legacy GPS attributes for backwards compatibility."""
+        return device_location_attributes(self.device)
 
     async def async_start_mowing(self) -> None:
         """Handle start command."""

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -9,10 +9,12 @@ def test_platforms_use_home_assistant_platform_enum() -> None:
     """Merged branch should expose every currently supported platform."""
     assert PLATFORMS == [
         Platform.LAWN_MOWER,
+        Platform.DEVICE_TRACKER,
         Platform.SENSOR,
         Platform.SELECT,
         Platform.NUMBER,
         Platform.BUTTON,
         Platform.SWITCH,
         Platform.BINARY_SENSOR,
+        Platform.UPDATE,
     ]

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1,0 +1,65 @@
+"""Tests for mower device tracker entities."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.landroid_cloud.device_tracker import (
+    LandroidCloudLocationEntity,
+    async_setup_entry,
+)
+
+
+def test_location_tracker_reports_coordinates() -> None:
+    """GPS-capable mowers should expose coordinates through the tracker."""
+    entity = object.__new__(LandroidCloudLocationEntity)
+    entity._serial_number = "serial"
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data={
+            "serial": SimpleNamespace(
+                gps={"latitude": 51.815106289, "longitude": 5.855785009666666}
+            )
+        },
+    )
+
+    assert entity.available is True
+    assert entity.name == "Location"
+    assert entity.latitude == 51.815106289
+    assert entity.longitude == 5.855785009666666
+    assert entity.entity_registry_enabled_default is False
+
+
+def test_location_tracker_is_unavailable_without_fix() -> None:
+    """Trackers should wait for real coordinates before reporting state."""
+    entity = object.__new__(LandroidCloudLocationEntity)
+    entity._serial_number = "serial"
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data={"serial": SimpleNamespace(module_status={"4G": {}}, gps={})},
+    )
+
+    assert entity.available is False
+    assert entity.latitude is None
+    assert entity.longitude is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_only_adds_trackers_for_gps_capable_mowers() -> None:
+    """Only mowers with a 4G/GPS module should create tracker entities."""
+    added_entities = []
+    coordinator = SimpleNamespace(
+        data={
+            "gps": SimpleNamespace(gps={"latitude": 1.0, "longitude": 2.0}),
+            "module": SimpleNamespace(module_config={"4G": {}}),
+            "plain": SimpleNamespace(),
+        }
+    )
+    entry = SimpleNamespace(runtime_data=SimpleNamespace(coordinator=coordinator))
+
+    def _async_add_entities(entities) -> None:
+        added_entities.extend(list(entities))
+
+    await async_setup_entry(None, entry, _async_add_entities)
+
+    assert [entity._serial_number for entity in added_entities] == ["gps", "module"]

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -4,6 +4,9 @@ from types import SimpleNamespace
 
 from custom_components.landroid_cloud.entity import (
     LandroidBaseEntity,
+    device_coordinates,
+    device_location_attributes,
+    device_supports_location,
     _firmware_version,
 )
 
@@ -24,6 +27,30 @@ def test_firmware_version_defaults_to_unknown() -> None:
     """Missing firmware data should return fallback."""
     device = SimpleNamespace(firmware=None)
     assert _firmware_version(device) == "unknown"
+
+
+def test_device_coordinates_reads_mapping_values() -> None:
+    """GPS coordinates should be normalized from mapping-like payloads."""
+    device = SimpleNamespace(gps={"latitude": 51.5, "longitude": 5.1})
+
+    assert device_coordinates(device) == (51.5, 5.1)
+
+
+def test_device_location_attributes_returns_legacy_keys() -> None:
+    """Legacy mower attributes should expose GPS coordinates unchanged."""
+    device = SimpleNamespace(gps={"latitude": 51.5, "longitude": 5.1})
+
+    assert device_location_attributes(device) == {
+        "latitude": 51.5,
+        "longitude": 5.1,
+    }
+
+
+def test_device_supports_location_checks_module_markers() -> None:
+    """A 4G module marker should be enough to create a tracker entity."""
+    device = SimpleNamespace(module_config={"4G": {}})
+
+    assert device_supports_location(device) is True
 
 
 class _ReadonlyEntity(LandroidBaseEntity):

--- a/tests/test_lawn_mower.py
+++ b/tests/test_lawn_mower.py
@@ -74,6 +74,24 @@ def test_rain_delay_activity_overrides_docked_when_remaining_minutes_exist() -> 
     assert entity.activity == MOWER_STATE_RAIN_DELAY
 
 
+def test_mower_restores_legacy_location_attributes() -> None:
+    """The mower entity should keep latitude/longitude for compatibility."""
+    entity = object.__new__(LandroidCloudMowerEntity)
+    entity._serial_number = "serial"
+    entity.coordinator = SimpleNamespace(
+        data={
+            "serial": SimpleNamespace(
+                gps={"latitude": 51.815106289, "longitude": 5.855785009666666}
+            )
+        }
+    )
+
+    assert entity.extra_state_attributes == {
+        "latitude": 51.815106289,
+        "longitude": 5.855785009666666,
+    }
+
+
 @pytest.mark.asyncio
 async def test_ots_service_calls_cloud_ots() -> None:
     """OTS service should call the cloud command with legacy arguments."""


### PR DESCRIPTION
## Summary
This restores mower location support in v7 by exposing a native Home Assistant `device_tracker` entity for mowers that report location support, while also restoring the legacy `latitude` and `longitude` attributes on the `lawn_mower` entity for backward compatibility.

The new location tracker is disabled by default and only created for mowers that expose location support. The README now documents both the tracker behavior and the restored legacy mower attributes.

Fixes #1230

## Test strategy
Automated local validation:
- `ruff format custom_components/landroid_cloud tests`
- `ruff check --fix custom_components/landroid_cloud tests`
- `pytest -q tests/test_const.py tests/test_entity.py tests/test_lawn_mower.py tests/test_device_tracker.py`

## Known limitations
- The `device_tracker` entity is only created for mowers that expose GPS/location support through the cloud payload.
- A created `device_tracker` may remain unavailable until the mower reports an actual GPS fix.
- Existing entity registry settings are not changed automatically for users who already customized entities locally.

## Configuration changes
No manual configuration changes are required.

## Semver
Proposed semver label: `patch`.
I have not set or changed any semver labels yet.
