### PR TITLE
feat: add set_border_cut_settings service

### DIFF
--- a/custom_components/landroid_cloud/lawn_mower.py
+++ b/custom_components/landroid_cloud/lawn_mower.py
@@ -36,6 +36,7 @@ from .services import (
     async_handle_edit_schedule,
     async_handle_edit_exclusion_schedule,
     async_handle_ots,
+    async_handle_set_border_cut_settings,
     async_handle_set_exclusion_day,
     async_handle_set_nutrition,
     async_register_entity_services,
@@ -282,4 +283,17 @@ class LandroidCloudMowerEntity(LandroidBaseEntity, LawnMowerEntity):
             self,
             day=day,
             start=start,
+        )
+
+    async def _async_service_set_border_cut_settings(
+        self,
+        *,
+        border_distance: int,
+        cut_over_border: bool,
+    ) -> None:
+        """Set border distance and cut-over-border mode."""
+        await async_handle_set_border_cut_settings(
+            self,
+            border_distance=border_distance,
+            cut_over_border=cut_over_border,
         )

--- a/custom_components/landroid_cloud/services.py
+++ b/custom_components/landroid_cloud/services.py
@@ -32,6 +32,7 @@ SERVICE_SET_EXCLUSION_DAY: Final = "set_exclusion_day"
 SERVICE_ADD_EXCLUSION_SCHEDULE: Final = "add_exclusion_schedule"
 SERVICE_EDIT_EXCLUSION_SCHEDULE: Final = "edit_exclusion_schedule"
 SERVICE_DELETE_EXCLUSION_SCHEDULE: Final = "delete_exclusion_schedule"
+SERVICE_SET_BORDER_CUT_SETTINGS: Final = "set_border_cut_settings"
 ATTR_EXCLUDE_DAY: Final = "exclude_day"
 ATTR_K: Final = "k"
 ATTR_N: Final = "n"
@@ -46,6 +47,9 @@ ATTR_DAYS: Final = "days"
 ATTR_DURATION: Final = "duration"
 ATTR_RUNTIME: Final = "runtime"
 ATTR_START: Final = "start"
+ATTR_BORDER_DISTANCE: Final = "border_distance"
+ATTR_CUT_OVER_BORDER: Final = "cut_over_border"
+BORDER_DISTANCE_VALUES: Final = (50, 100, 150, 200)
 DAYS: Final = tuple(DAY_MAP[index] for index in sorted(DAY_MAP))
 EXCLUSION_REASONS: Final = ("generic", "irrigation")
 
@@ -240,6 +244,16 @@ def async_register_entity_services(platform: EntityPlatform) -> None:
             vol.Optional(ATTR_START): cv.string,
         },
         "_async_service_delete_exclusion_schedule",
+    )
+    platform.async_register_entity_service(
+        SERVICE_SET_BORDER_CUT_SETTINGS,
+        {
+            vol.Required(ATTR_BORDER_DISTANCE): vol.All(
+                vol.Coerce(int), vol.In(BORDER_DISTANCE_VALUES)
+            ),
+            vol.Required(ATTR_CUT_OVER_BORDER): bool,
+        },
+        "_async_service_set_border_cut_settings",
     )
 
 
@@ -752,5 +766,44 @@ async def async_handle_delete_exclusion_schedule(
     await async_run_cloud_command(
         lambda: entity.coordinator.cloud.set_auto_schedule_exclusion_slots(
             serial_number, day_index, updated_slots
+        )
+    )
+
+
+async def async_handle_set_border_cut_settings(
+    entity: LandroidCloudMowerEntity,
+    *,
+    border_distance: int,
+    cut_over_border: bool,
+) -> None:
+    """Set border cut distance and cut-over-border mode on the mower."""
+    cloud = entity.coordinator.cloud
+    serial_number = str(entity.device.serial_number)
+    mower = cloud.get_mower(serial_number)
+
+    if not mower["online"]:
+        raise HomeAssistantError("Mower is unavailable")
+
+    ob = 1 if cut_over_border else 0
+
+    if mower["protocol"] == 0:
+        payload = {"cfg": {"cut": {"bd": border_distance, "ob": ob}}}
+        identifier = serial_number
+    else:
+        # Protocol 1 (Vision): zone-level cfg — mirrors the mz.s payload structure
+        payload = {
+            "mz": {
+                "s": [{"id": 1, "c": 1, "cfg": {"cut": {"bd": border_distance, "ob": ob}}}],
+                "p": [],
+            }
+        }
+        identifier = mower["uuid"]
+
+    await async_run_cloud_command(
+        lambda: cloud.mqtt.apublish(
+            identifier,
+            mower["mqtt_topics"]["command_in"],
+            payload,
+            mower["protocol"],
         )
     )

--- a/custom_components/landroid_cloud/services.yaml
+++ b/custom_components/landroid_cloud/services.yaml
@@ -424,3 +424,29 @@ delete_exclusion_schedule:
       example: "09:00"
       selector:
         text:
+set_border_cut_settings:
+  description: Set border cut distance and cut-over-border mode (Worx Vision models)
+  target:
+    entity:
+      integration: landroid_cloud
+      domain: lawn_mower
+  fields:
+    border_distance:
+      name: Border distance
+      description: Distance from the border in mm (50, 100, 150 or 200)
+      example: 150
+      required: true
+      selector:
+        number:
+          min: 50
+          max: 200
+          step: 50
+          unit_of_measurement: mm
+          mode: slider
+    cut_over_border:
+      name: Cut over border
+      description: Enable cutting over the physical border
+      example: false
+      required: true
+      selector:
+        boolean:


### PR DESCRIPTION
## Summary

Adds a new entity service `landroid_cloud.set_border_cut_settings` to persistently configure border cut settings on the mower device — without requiring HA to manage mowing sessions (unlike the OTS approach).

This closes the feature request in #876 and replaces the workaround that previously used the now-removed `send_raw` service.

**Parameters:**
- `border_distance` (int): 50, 100, 150 or 200 mm
- `cut_over_border` (bool): enables/disables the "Cut Over Border" feature

**Example usage:**
```yaml
action: landroid_cloud.set_border_cut_settings
target:
  entity_id: lawn_mower.my_mower
data:
  border_distance: 150
  cut_over_border: false
```

## Implementation notes

- **Protocol 1 (Vision models):** sends the `mz.s` payload structure — verified working on WR206E
- **Protocol 0 (legacy):** sends via `cfg.cut` — follows the same pattern as other cfg commands (untested on real hardware)
- The service accesses `cloud.get_mower()` and `cloud.mqtt.apublish()` directly since pyworxcloud does not yet expose a `set_border_cut_settings` method. If desired, this logic could optionally be moved into pyworxcloud as a dedicated method (analogous to `set_torque`), and the integration updated to call it — but that's a separate step.
- MTrab noted that `bd`/`ob` values are not reflected back in the API response, which is why this is a service (fire-and-forget config update) rather than stateful entities.

## Test plan

- [x] Tested on Worx Landroid Vision WR206E (protocol 1), HA 2026.4.4, integration v7.0.5
- [x] Verified `border_distance` and `cut_over_border` change reflected in Worx app after service call
- [x] No errors in HA log on successful call
- [x] Mower continues on its own internal schedule after config update (no session takeover)
- [ ] Protocol 0 hardware test (not available — community feedback welcome)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)