### PR TITLE
Centralize integration constants

### DIFF
--- a/custom_components/landroid_cloud/const.py
+++ b/custom_components/landroid_cloud/const.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from enum import StrEnum
 
 from homeassistant.const import Platform
+from pyworxcloud.day_map import DAY_MAP
 
 DOMAIN = "landroid_cloud"
 
@@ -96,3 +97,47 @@ ERROR_STATE_MAP: dict[int, str] = {
     116: "blade_height_adjustment_blocked",
 }
 ERROR_STATE_OPTIONS: tuple[str, ...] = tuple(dict.fromkeys(ERROR_STATE_MAP.values()))
+
+SERVICE_OTS = "ots"
+SERVICE_SET_BORDER_CUT_SETTINGS = "set_border_cut_settings"
+SERVICE_ADD_SCHEDULE = "add_schedule"
+SERVICE_EDIT_SCHEDULE = "edit_schedule"
+SERVICE_DELETE_SCHEDULE = "delete_schedule"
+SERVICE_SET_NUTRITION = "set_nutrition"
+SERVICE_CLEAR_NUTRITION = "clear_nutrition"
+SERVICE_SET_EXCLUSION_DAY = "set_exclusion_day"
+SERVICE_ADD_EXCLUSION_SCHEDULE = "add_exclusion_schedule"
+SERVICE_EDIT_EXCLUSION_SCHEDULE = "edit_exclusion_schedule"
+SERVICE_DELETE_EXCLUSION_SCHEDULE = "delete_exclusion_schedule"
+
+ATTR_EXCLUDE_DAY = "exclude_day"
+ATTR_K = "k"
+ATTR_N = "n"
+ATTR_P = "p"
+ATTR_REASON = "reason"
+ATTR_BOUNDARY = "boundary"
+ATTR_ALL_SCHEDULES = "all_schedules"
+ATTR_CURRENT_DAY = "current_day"
+ATTR_CURRENT_START = "current_start"
+ATTR_DAY = "day"
+ATTR_DAYS = "days"
+ATTR_DURATION = "duration"
+ATTR_RUNTIME = "runtime"
+ATTR_CUT_OVER_BORDER = "cut_over_border"
+ATTR_BORDER_DISTANCE_CM = "border_distance_cm"
+ATTR_START = "start"
+
+DAYS = tuple(DAY_MAP[index] for index in sorted(DAY_MAP))
+EXCLUSION_REASONS = ("generic", "irrigation")
+VISION_BORDER_DISTANCE_CM_VALUES = (5, 10, 15, 20)
+
+AUTO_SCHEDULE_BOOST_OPTIONS = ("0", "1", "2")
+AUTO_SCHEDULE_GRASS_TYPE_OPTIONS = (
+    "mixed_species",
+    "festuca_arundinacea",
+    "lolium_perenne",
+    "poa_pratensis",
+    "festuca_rubra",
+    "agrostis_stolonifera",
+)
+AUTO_SCHEDULE_SOIL_TYPE_OPTIONS = ("clay", "silt", "sand", "ignore")

--- a/custom_components/landroid_cloud/device_action.py
+++ b/custom_components/landroid_cloud/device_action.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 from homeassistant.components.device_automation import async_validate_entity_schema
 from homeassistant.components.lawn_mower import LawnMowerEntityFeature
 from homeassistant.components.lawn_mower.const import (
+    DOMAIN as MOWER_DOMAIN,
     SERVICE_DOCK,
     SERVICE_PAUSE,
     SERVICE_START_MOWING,
@@ -24,9 +25,8 @@ from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity import get_supported_features
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
-from . import DOMAIN
+from .const import DOMAIN
 
-MOWER_DOMAIN: Final = "lawn_mower"
 ACTION_TO_SERVICE: Final[dict[str, str]] = {
     "start_mowing": SERVICE_START_MOWING,
     "pause": SERVICE_PAUSE,

--- a/custom_components/landroid_cloud/device_condition.py
+++ b/custom_components/landroid_cloud/device_condition.py
@@ -6,6 +6,7 @@ from typing import Final
 
 import voluptuous as vol
 from homeassistant.components.lawn_mower import LawnMowerActivity
+from homeassistant.components.lawn_mower.const import DOMAIN as MOWER_DOMAIN
 from homeassistant.const import (
     CONF_CONDITION,
     CONF_DEVICE_ID,
@@ -22,8 +23,8 @@ from homeassistant.helpers import (
 from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
-from . import DOMAIN
 from .const import (
+    DOMAIN,
     MOWER_STATE_EDGECUT,
     MOWER_STATE_ESCAPED_DIGITAL_FENCE,
     MOWER_STATE_IDLE,
@@ -33,7 +34,6 @@ from .const import (
     MOWER_STATE_ZONING,
 )
 
-MOWER_DOMAIN: Final = "lawn_mower"
 CONDITION_STATE_MAP: Final[dict[str, tuple[str, ...]]] = {
     "is_mowing": (LawnMowerActivity.MOWING,),
     "is_docked": (LawnMowerActivity.DOCKED,),

--- a/custom_components/landroid_cloud/device_trigger.py
+++ b/custom_components/landroid_cloud/device_trigger.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.homeassistant.triggers import state as state_trigger
 from homeassistant.components.lawn_mower import LawnMowerActivity
+from homeassistant.components.lawn_mower.const import DOMAIN as MOWER_DOMAIN
 from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_DOMAIN,
@@ -21,8 +22,8 @@ from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
-from . import DOMAIN
 from .const import (
+    DOMAIN,
     MOWER_STATE_EDGECUT,
     MOWER_STATE_ESCAPED_DIGITAL_FENCE,
     MOWER_STATE_IDLE,
@@ -32,7 +33,6 @@ from .const import (
     MOWER_STATE_ZONING,
 )
 
-MOWER_DOMAIN: Final = "lawn_mower"
 TRIGGER_STATE_MAP: Final[dict[str, str]] = {
     "mowing": LawnMowerActivity.MOWING,
     "docked": LawnMowerActivity.DOCKED,

--- a/custom_components/landroid_cloud/lawn_mower.py
+++ b/custom_components/landroid_cloud/lawn_mower.py
@@ -17,7 +17,6 @@ from homeassistant.helpers import entity_platform
 
 from .commands import async_run_cloud_command
 from .entity import LandroidBaseEntity, device_location_attributes
-from . import services as integration_services
 from .const import (
     MOWER_STATE_EDGECUT,
     MOWER_STATE_ESCAPED_DIGITAL_FENCE,
@@ -26,6 +25,17 @@ from .const import (
     MOWER_STATE_SEARCHING_ZONE,
     MOWER_STATE_STARTING,
     MOWER_STATE_ZONING,
+    SERVICE_ADD_EXCLUSION_SCHEDULE,
+    SERVICE_ADD_SCHEDULE,
+    SERVICE_CLEAR_NUTRITION,
+    SERVICE_DELETE_EXCLUSION_SCHEDULE,
+    SERVICE_DELETE_SCHEDULE,
+    SERVICE_EDIT_EXCLUSION_SCHEDULE,
+    SERVICE_EDIT_SCHEDULE,
+    SERVICE_OTS,
+    SERVICE_SET_BORDER_CUT_SETTINGS,
+    SERVICE_SET_EXCLUSION_DAY,
+    SERVICE_SET_NUTRITION,
 )
 from .services import (
     async_handle_add_schedule,
@@ -41,6 +51,20 @@ from .services import (
     async_handle_set_nutrition,
     async_register_entity_services,
 )
+
+__all__ = [
+    "SERVICE_ADD_EXCLUSION_SCHEDULE",
+    "SERVICE_ADD_SCHEDULE",
+    "SERVICE_CLEAR_NUTRITION",
+    "SERVICE_DELETE_EXCLUSION_SCHEDULE",
+    "SERVICE_DELETE_SCHEDULE",
+    "SERVICE_EDIT_EXCLUSION_SCHEDULE",
+    "SERVICE_EDIT_SCHEDULE",
+    "SERVICE_OTS",
+    "SERVICE_SET_BORDER_CUT_SETTINGS",
+    "SERVICE_SET_EXCLUSION_DAY",
+    "SERVICE_SET_NUTRITION",
+]
 
 STATUS_ACTIVITY_MAP: Final[dict[int, str]] = {
     0: MOWER_STATE_IDLE,
@@ -67,25 +91,6 @@ STATUS_ACTIVITY_MAP: Final[dict[int, str]] = {
 }
 MOWER_DESCRIPTION: Final = LawnMowerEntityEntityDescription(
     key="mower", translation_key="mower"
-)
-SERVICE_OTS: Final = integration_services.SERVICE_OTS
-SERVICE_SET_BORDER_CUT_SETTINGS: Final = (
-    integration_services.SERVICE_SET_BORDER_CUT_SETTINGS
-)
-SERVICE_ADD_SCHEDULE: Final = integration_services.SERVICE_ADD_SCHEDULE
-SERVICE_EDIT_SCHEDULE: Final = integration_services.SERVICE_EDIT_SCHEDULE
-SERVICE_DELETE_SCHEDULE: Final = integration_services.SERVICE_DELETE_SCHEDULE
-SERVICE_SET_NUTRITION: Final = integration_services.SERVICE_SET_NUTRITION
-SERVICE_CLEAR_NUTRITION: Final = integration_services.SERVICE_CLEAR_NUTRITION
-SERVICE_SET_EXCLUSION_DAY: Final = integration_services.SERVICE_SET_EXCLUSION_DAY
-SERVICE_ADD_EXCLUSION_SCHEDULE: Final = (
-    integration_services.SERVICE_ADD_EXCLUSION_SCHEDULE
-)
-SERVICE_EDIT_EXCLUSION_SCHEDULE: Final = (
-    integration_services.SERVICE_EDIT_EXCLUSION_SCHEDULE
-)
-SERVICE_DELETE_EXCLUSION_SCHEDULE: Final = (
-    integration_services.SERVICE_DELETE_EXCLUSION_SCHEDULE
 )
 
 

--- a/custom_components/landroid_cloud/select.py
+++ b/custom_components/landroid_cloud/select.py
@@ -13,18 +13,12 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .commands import async_run_cloud_command
-from .entity import LandroidBaseEntity, auto_schedule_settings
-
-AUTO_SCHEDULE_BOOST_OPTIONS: Final = ("0", "1", "2")
-AUTO_SCHEDULE_GRASS_TYPE_OPTIONS: Final = (
-    "mixed_species",
-    "festuca_arundinacea",
-    "lolium_perenne",
-    "poa_pratensis",
-    "festuca_rubra",
-    "agrostis_stolonifera",
+from .const import (
+    AUTO_SCHEDULE_BOOST_OPTIONS,
+    AUTO_SCHEDULE_GRASS_TYPE_OPTIONS,
+    AUTO_SCHEDULE_SOIL_TYPE_OPTIONS,
 )
-AUTO_SCHEDULE_SOIL_TYPE_OPTIONS: Final = ("clay", "silt", "sand", "ignore")
+from .entity import LandroidBaseEntity, auto_schedule_settings
 
 
 def _configured_legacy_zone_options(device) -> list[str]:

--- a/custom_components/landroid_cloud/services.py
+++ b/custom_components/landroid_cloud/services.py
@@ -2,56 +2,57 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 from homeassistant.exceptions import HomeAssistantError
 from pyworxcloud import ScheduleEntry, ScheduleModel
-from pyworxcloud.day_map import DAY_MAP
 from pyworxcloud.exceptions import NoOneTimeScheduleError
 from pyworxcloud.utils.schedule_codec import (
     add_schedule_entry as add_schedule_entry_model,
 )
 
 from .commands import async_run_cloud_command
+from .const import (
+    ATTR_ALL_SCHEDULES,
+    ATTR_BORDER_DISTANCE_CM,
+    ATTR_BOUNDARY,
+    ATTR_CURRENT_DAY,
+    ATTR_CURRENT_START,
+    ATTR_CUT_OVER_BORDER,
+    ATTR_DAY,
+    ATTR_DAYS,
+    ATTR_DURATION,
+    ATTR_EXCLUDE_DAY,
+    ATTR_K,
+    ATTR_N,
+    ATTR_P,
+    ATTR_REASON,
+    ATTR_RUNTIME,
+    ATTR_START,
+    DAYS,
+    DAY_MAP,
+    EXCLUSION_REASONS,
+    SERVICE_ADD_EXCLUSION_SCHEDULE,
+    SERVICE_ADD_SCHEDULE,
+    SERVICE_CLEAR_NUTRITION,
+    SERVICE_DELETE_EXCLUSION_SCHEDULE,
+    SERVICE_DELETE_SCHEDULE,
+    SERVICE_EDIT_EXCLUSION_SCHEDULE,
+    SERVICE_EDIT_SCHEDULE,
+    SERVICE_OTS,
+    SERVICE_SET_BORDER_CUT_SETTINGS,
+    SERVICE_SET_EXCLUSION_DAY,
+    SERVICE_SET_NUTRITION,
+    VISION_BORDER_DISTANCE_CM_VALUES,
+)
 from .entity import auto_schedule_enabled, auto_schedule_settings
 
 if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import EntityPlatform
 
     from .lawn_mower import LandroidCloudMowerEntity
-
-SERVICE_OTS: Final = "ots"
-SERVICE_SET_BORDER_CUT_SETTINGS: Final = "set_border_cut_settings"
-SERVICE_ADD_SCHEDULE: Final = "add_schedule"
-SERVICE_EDIT_SCHEDULE: Final = "edit_schedule"
-SERVICE_DELETE_SCHEDULE: Final = "delete_schedule"
-SERVICE_SET_NUTRITION: Final = "set_nutrition"
-SERVICE_CLEAR_NUTRITION: Final = "clear_nutrition"
-SERVICE_SET_EXCLUSION_DAY: Final = "set_exclusion_day"
-SERVICE_ADD_EXCLUSION_SCHEDULE: Final = "add_exclusion_schedule"
-SERVICE_EDIT_EXCLUSION_SCHEDULE: Final = "edit_exclusion_schedule"
-SERVICE_DELETE_EXCLUSION_SCHEDULE: Final = "delete_exclusion_schedule"
-ATTR_EXCLUDE_DAY: Final = "exclude_day"
-ATTR_K: Final = "k"
-ATTR_N: Final = "n"
-ATTR_P: Final = "p"
-ATTR_REASON: Final = "reason"
-ATTR_BOUNDARY: Final = "boundary"
-ATTR_ALL_SCHEDULES: Final = "all_schedules"
-ATTR_CURRENT_DAY: Final = "current_day"
-ATTR_CURRENT_START: Final = "current_start"
-ATTR_DAY: Final = "day"
-ATTR_DAYS: Final = "days"
-ATTR_DURATION: Final = "duration"
-ATTR_RUNTIME: Final = "runtime"
-ATTR_CUT_OVER_BORDER: Final = "cut_over_border"
-ATTR_BORDER_DISTANCE_CM: Final = "border_distance_cm"
-ATTR_START: Final = "start"
-DAYS: Final = tuple(DAY_MAP[index] for index in sorted(DAY_MAP))
-EXCLUSION_REASONS: Final = ("generic", "irrigation")
-VISION_BORDER_DISTANCE_CM_VALUES: Final = (5, 10, 15, 20)
 
 
 def _normalize_day(day: str | None, field_name: str) -> str:


### PR DESCRIPTION
## Description
Centralizes shared service names, service attributes, schedule option values, and auto-schedule select options in `custom_components/landroid_cloud/const.py`.

Updates service, select, lawn mower, and device automation modules to import the shared constants from their canonical sources. The Home Assistant lawn mower platform domain is now imported from `homeassistant.components.lawn_mower.const` instead of being duplicated locally.

## Test strategy
- `python3.14 -m ruff format custom_components tests`
- `python3.14 -m ruff check --fix custom_components tests`
- `python3.14 -m pytest`

## Known limitations
No functional behavior changes are intended. This PR only reorganizes constant definitions and imports.

## Required configuration changes
None.

## Semver
Proposed semver label: `patch`. I have not applied a semver label yet; please confirm before labeling for merge.