### PR TITLE
Fix Vision border cut settings service

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -13,7 +13,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud==6.4.0b2"
+        "pyworxcloud==6.4.0b3"
     ],
     "version": "7.1.0b2"
 }

--- a/custom_components/landroid_cloud/services.py
+++ b/custom_components/landroid_cloud/services.py
@@ -390,8 +390,20 @@ async def async_handle_set_border_cut_settings(
     cloud = entity.coordinator.cloud
     set_cut_over_border = getattr(cloud, "set_cut_over_border", None)
     set_border_distance = getattr(cloud, "set_border_distance", None)
-    set_border_cut_settings = getattr(cloud, "set_border_cut_settings", None)
+    set_border_cut_settings = getattr(
+        cloud, "set_border_cut_settings", None
+    ) or getattr(cloud, "_set_border_cut_settings", None)
     try:
+        if callable(set_border_cut_settings):
+            await async_run_cloud_command(
+                lambda: set_border_cut_settings(
+                    serial_number,
+                    cut_over_border=cut_over_border,
+                    border_distance=border_distance,
+                )
+            )
+            return
+
         if callable(set_cut_over_border) and callable(set_border_distance):
             await async_run_cloud_command(
                 lambda: set_cut_over_border(
@@ -403,16 +415,6 @@ async def async_handle_set_border_cut_settings(
                 lambda: set_border_distance(
                     serial_number,
                     border_distance,
-                )
-            )
-            return
-
-        if callable(set_border_cut_settings):
-            await async_run_cloud_command(
-                lambda: set_border_cut_settings(
-                    serial_number,
-                    cut_over_border=cut_over_border,
-                    border_distance=border_distance,
                 )
             )
             return

--- a/tests/test_lawn_mower.py
+++ b/tests/test_lawn_mower.py
@@ -110,8 +110,58 @@ async def test_ots_service_calls_cloud_ots() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_border_cut_settings_service_calls_dedicated_cloud_helpers() -> None:
-    """Border-cut settings service should use dedicated cloud helpers."""
+async def test_set_border_cut_settings_service_prefers_combined_cloud_helper() -> None:
+    """Border-cut settings service should send both values in one cloud command."""
+    entity = object.__new__(LandroidCloudMowerEntity)
+    entity._serial_number = "serial"
+    entity.coordinator = SimpleNamespace(
+        cloud=SimpleNamespace(
+            set_border_cut_settings=AsyncMock(),
+            set_cut_over_border=AsyncMock(),
+            set_border_distance=AsyncMock(),
+        ),
+        data={"serial": SimpleNamespace(serial_number="serial")},
+    )
+
+    await entity._async_service_set_border_cut_settings(
+        cut_over_border=False,
+        border_distance_cm=15,
+    )
+
+    entity.coordinator.cloud.set_border_cut_settings.assert_awaited_once_with(
+        "serial",
+        cut_over_border=False,
+        border_distance=150,
+    )
+    entity.coordinator.cloud.set_cut_over_border.assert_not_awaited()
+    entity.coordinator.cloud.set_border_distance.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_border_cut_settings_service_supports_private_beta_helper() -> None:
+    """Border-cut settings service should support the beta combined helper."""
+    entity = object.__new__(LandroidCloudMowerEntity)
+    entity._serial_number = "serial"
+    entity.coordinator = SimpleNamespace(
+        cloud=SimpleNamespace(_set_border_cut_settings=AsyncMock()),
+        data={"serial": SimpleNamespace(serial_number="serial")},
+    )
+
+    await entity._async_service_set_border_cut_settings(
+        cut_over_border=False,
+        border_distance_cm=15,
+    )
+
+    entity.coordinator.cloud._set_border_cut_settings.assert_awaited_once_with(
+        "serial",
+        cut_over_border=False,
+        border_distance=150,
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_border_cut_settings_service_falls_back_to_separate_helpers() -> None:
+    """Border-cut settings service should support older separate cloud helpers."""
     entity = object.__new__(LandroidCloudMowerEntity)
     entity._serial_number = "serial"
     entity.coordinator = SimpleNamespace(
@@ -134,28 +184,6 @@ async def test_set_border_cut_settings_service_calls_dedicated_cloud_helpers() -
     entity.coordinator.cloud.set_border_distance.assert_awaited_once_with(
         "serial",
         150,
-    )
-
-
-@pytest.mark.asyncio
-async def test_set_border_cut_settings_service_supports_legacy_cloud_helper() -> None:
-    """Border-cut settings service should support the previous combined helper."""
-    entity = object.__new__(LandroidCloudMowerEntity)
-    entity._serial_number = "serial"
-    entity.coordinator = SimpleNamespace(
-        cloud=SimpleNamespace(set_border_cut_settings=AsyncMock()),
-        data={"serial": SimpleNamespace(serial_number="serial")},
-    )
-
-    await entity._async_service_set_border_cut_settings(
-        cut_over_border=False,
-        border_distance_cm=15,
-    )
-
-    entity.coordinator.cloud.set_border_cut_settings.assert_awaited_once_with(
-        "serial",
-        cut_over_border=False,
-        border_distance=150,
     )
 
 


### PR DESCRIPTION
## Description
Update the border-cut settings service to prefer the combined `set_border_cut_settings` pyworxcloud helper so `cut_over_border` and `border_distance` are sent in one command. This matches Vision firmware behavior where partial `cut` updates can be ignored.

The manifest now requires `pyworxcloud==6.4.0b3`, which includes the public combined helper. A fallback to the private beta helper and older separate helpers remains for compatibility during development/test runtimes.

## Test strategy
- `ruff format`
- `ruff check --fix`
- `pytest tests/test_lawn_mower.py -k border_cut_setting`

## Known limitations
No physical mower validation was performed; behavior is covered by service tests and the pyworxcloud MQTT publish tests from MTrab/pyworxcloud#388.

## Required configuration changes
None.

## Semver
Proposed label: patch

Fixes #876