### PR TITLE
Use fixed border cut payload module branch

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -13,7 +13,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud==6.4.0b3"
+        "pyworxcloud@git+https://github.com/MTrab/pyworxcloud.git@fix/border-cut-settings-cut-payload"
     ],
     "version": "7.1.0b2"
 }

--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -13,7 +13,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud@git+https://github.com/MTrab/pyworxcloud.git@fix/border-cut-settings-cut-payload"
+        "pyworxcloud==6.4.0b4"
     ],
     "version": "7.1.0b2"
 }


### PR DESCRIPTION
## Description
Temporarily point the integration at the pyworxcloud branch from MTrab/pyworxcloud#390 so border-cut settings no longer use the released `6.4.0b3` payload that wraps `cut` settings in `mz` and can clear zone data.

This PR should be updated to the next released pyworxcloud version before merge.

## Test strategy
- `ruff format`
- `ruff check --fix`
- `pytest tests/test_lawn_mower.py -k border_cut_setting`

## Known limitations
This intentionally uses a git branch dependency for the test cycle only. It must be reverted to a PyPI version after the pyworxcloud fix is released.

## Required configuration changes
None.

## Semver
Proposed label: patch

Refs #876