### PR TITLE
Let account credentials be updated from options

### DIFF
--- a/custom_components/landroid_cloud/config_flow.py
+++ b/custom_components/landroid_cloud/config_flow.py
@@ -25,12 +25,8 @@ from pyworxcloud.exceptions import (
 from .awsiot import async_prime_awsiot_metrics
 from .const import (
     CONF_CLOUD,
-    CONF_COMMAND_TIMEOUT,
     DEFAULT_CLOUD,
-    DEFAULT_COMMAND_TIMEOUT,
     DOMAIN,
-    MAX_COMMAND_TIMEOUT,
-    MIN_COMMAND_TIMEOUT,
 )
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
@@ -45,6 +41,23 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         ),
     }
 )
+
+
+def _target_unique_id(email: str, cloud: str) -> str:
+    """Return the canonical config entry unique id."""
+    return f"{email.lower()}::{cloud}"
+
+
+def _unique_id_conflicts(hass, config_entry, unique_id: str) -> bool:
+    """Return whether another config entry already uses the target unique id."""
+    for other_entry in hass.config_entries.async_entries(DOMAIN):
+        if (
+            other_entry.entry_id != config_entry.entry_id
+            and other_entry.unique_id == unique_id
+        ):
+            return True
+
+    return False
 
 
 async def _validate_input(user_input: dict[str, Any]) -> dict[str, Any]:
@@ -82,7 +95,9 @@ class LandroidCloudConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            unique_id = f"{user_input[CONF_EMAIL].lower()}::{user_input[CONF_CLOUD]}"
+            unique_id = _target_unique_id(
+                user_input[CONF_EMAIL], user_input[CONF_CLOUD]
+            )
             await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured()
 
@@ -124,24 +139,53 @@ class LandroidCloudOptionsFlow(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage options."""
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+        errors: dict[str, str] = {}
 
-        current = self._config_entry.options.get(
-            CONF_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT
-        )
+        if user_input is not None:
+            updated_data = {
+                **self._config_entry.data,
+                CONF_EMAIL: user_input[CONF_EMAIL],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+            }
+            cloud = updated_data.get(CONF_CLOUD, DEFAULT_CLOUD)
+            updated_data[CONF_CLOUD] = cloud
+            unique_id = _target_unique_id(user_input[CONF_EMAIL], cloud)
+
+            if _unique_id_conflicts(self.hass, self._config_entry, unique_id):
+                errors["base"] = "already_exists"
+            else:
+                try:
+                    info = await _validate_input(updated_data)
+                except AuthorizationError:
+                    errors["base"] = "invalid_auth"
+                except TooManyRequestsError:
+                    errors["base"] = "too_many_requests"
+                except NoConnectionError, ServiceUnavailableError:
+                    errors["base"] = "cannot_connect"
+                except RequestError, ForbiddenError, NotFoundError, InternalServerError:
+                    errors["base"] = "api_error"
+                except APIException:
+                    errors["base"] = "unknown"
+                except TimeoutError:
+                    errors["base"] = "timeout"
+                else:
+                    self.hass.config_entries.async_update_entry(
+                        self._config_entry,
+                        data=updated_data,
+                        title=info["title"],
+                        unique_id=unique_id,
+                    )
+                    return self.async_create_entry(title="", data={})
+
+        current_email = self._config_entry.data[CONF_EMAIL]
 
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_COMMAND_TIMEOUT, default=current): vol.All(
-                        vol.Coerce(float),
-                        vol.Range(
-                            min=MIN_COMMAND_TIMEOUT,
-                            max=MAX_COMMAND_TIMEOUT,
-                        ),
-                    )
+                    vol.Required(CONF_EMAIL, default=current_email): str,
+                    vol.Required(CONF_PASSWORD): str,
                 }
             ),
+            errors=errors,
         )

--- a/custom_components/landroid_cloud/translations/cs.json
+++ b/custom_components/landroid_cloud/translations/cs.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Možnosti Landroid Cloud",
         "data": {
-          "command_timeout": "Časový limit příkazu (sekundy)"
+          "email": "Email",
+          "password": "Heslo"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Chyba připojení",
+      "invalid_auth": "Chyba přihlášení",
+      "too_many_requests": "Příliš mnoho požadavků na API – Zkuste to znovu za 24 hodin.",
+      "api_error": "Cloud API požadavek odmítlo",
+      "timeout": "Vypršel časový limit připojení",
+      "unknown": "Neočekávaná chyba",
+      "already_exists": "Tento uživatelský účet již byl nastaven"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/da.json
+++ b/custom_components/landroid_cloud/translations/da.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Landroid Cloud-indstillinger",
         "data": {
-          "command_timeout": "Kommandotimeout (sekunder)"
+          "email": "E-mail",
+          "password": "Kodeord"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Kunne ikke forbinde",
+      "invalid_auth": "Fejl i brugernavn og/eller password",
+      "too_many_requests": "For mange forespørgsler mod API - Prøv igen om 24 timer",
+      "api_error": "Cloud-API afviste forespørgslen",
+      "timeout": "Forbindelsen fik timeout",
+      "unknown": "Ukendt fejl",
+      "already_exists": "Denne konto er allerede konfigureret"
     }
   },
   "services": {

--- a/custom_components/landroid_cloud/translations/de.json
+++ b/custom_components/landroid_cloud/translations/de.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Landroid Cloud Optionen",
         "data": {
-          "command_timeout": "Befehls-Timeout (Sekunden)"
+          "email": "E-Mail",
+          "password": "Passwort"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Verbindung ist nicht möglich",
+      "invalid_auth": "Fehler bei der Authentifizierung",
+      "too_many_requests": "Zu viele API-Anfragen - In 24 Stunden erneut versuchen",
+      "api_error": "Die Cloud-API hat die Anfrage abgelehnt",
+      "timeout": "Zeitüberschreitung bei der Verbindung",
+      "unknown": "Unerwarteter Fehler",
+      "already_exists": "Dieses Benutzerkonto wurde bereits konfiguriert"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/en.json
+++ b/custom_components/landroid_cloud/translations/en.json
@@ -55,9 +55,19 @@
       "init": {
         "title": "Landroid Cloud options",
         "data": {
-          "command_timeout": "Command timeout (seconds)"
+          "email": "Email",
+          "password": "Password"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to cloud service",
+      "invalid_auth": "Invalid credentials",
+      "too_many_requests": "Too many requests",
+      "api_error": "Cloud API rejected the request",
+      "timeout": "Connection timed out",
+      "unknown": "Unexpected error",
+      "already_exists": "This account is already configured"
     }
   },
   "services": {

--- a/custom_components/landroid_cloud/translations/es.json
+++ b/custom_components/landroid_cloud/translations/es.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Opciones de Landroid Cloud",
         "data": {
-          "command_timeout": "Tiempo de espera del comando (segundos)"
+          "email": "Envíe un correo electrónico a",
+          "password": "Contraseña"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Fallo en la conexión",
+      "invalid_auth": "Error en la autentificación",
+      "too_many_requests": "Demasiadas solicitudes a la API: vuelva a intentarlo en 24 horas",
+      "api_error": "La API en la nube rechazó la solicitud",
+      "timeout": "Tiempo de espera de conexión agotado",
+      "unknown": "Error inesperado",
+      "already_exists": "Esta cuenta de usuario ya ha sido configurada"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/et.json
+++ b/custom_components/landroid_cloud/translations/et.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Landroid Cloud seaded",
         "data": {
-          "command_timeout": "Käsu ajalimiit (sekundites)"
+          "email": "E-post",
+          "password": "Salasõna"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Ühendamine ebaõnnestus",
+      "invalid_auth": "Viga autentimisel",
+      "too_many_requests": "Liiga palju päringuid API-le - proovige uuesti 24 tunni pärast.",
+      "api_error": "Pilve API lükkas päringu tagasi",
+      "timeout": "Ühenduse ajalimiit ületatud",
+      "unknown": "Ootamatu viga",
+      "already_exists": "See kasutajakonto on juba konfigureeritud"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/fr.json
+++ b/custom_components/landroid_cloud/translations/fr.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Options Landroid Cloud",
         "data": {
-          "command_timeout": "Délai d'expiration des commandes (secondes)"
+          "email": "Email",
+          "password": "Mot de passe"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Échec de la connexion",
+      "invalid_auth": "Erreur d'authentification",
+      "too_many_requests": "Trop de requêtes",
+      "api_error": "L'API cloud a rejeté la requête",
+      "timeout": "Délai de connexion dépassé",
+      "unknown": "Erreur inattendue",
+      "already_exists": "Ce compte d'utilisateur a déjà été configuré"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/hu.json
+++ b/custom_components/landroid_cloud/translations/hu.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Landroid Cloud beállítások",
         "data": {
-          "command_timeout": "Parancs időtúllépés (másodperc)"
+          "email": "E-mail",
+          "password": "Jelszó"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Kapcsolódási hiba",
+      "invalid_auth": "Hitelesítési hiba",
+      "too_many_requests": "Túl sok API hívás. Próbálja meg 24 óra múlva",
+      "api_error": "A felhő API elutasította a kérést",
+      "timeout": "Kapcsolódási időtúllépés",
+      "unknown": "Váratlan hiba",
+      "already_exists": "Ez a felhasználói fiók már be van állítva"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/it.json
+++ b/custom_components/landroid_cloud/translations/it.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Opzioni Landroid Cloud",
         "data": {
-          "command_timeout": "Timeout comando (secondi)"
+          "email": "Email",
+          "password": "Password"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Impossibile connettersi",
+      "invalid_auth": "Errore di autenticazione",
+      "too_many_requests": "Troppe richieste alle API - Riprova tra 24 ore",
+      "api_error": "La Cloud API ha rifiutato la richiesta",
+      "timeout": "Timeout di connessione",
+      "unknown": "Errore inaspettato",
+      "already_exists": "Questo account è già stato configurato"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/nb.json
+++ b/custom_components/landroid_cloud/translations/nb.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Landroid Cloud-alternativer",
         "data": {
-          "command_timeout": "Tidsavbrudd for kommando (sekunder)"
+          "email": "E-post",
+          "password": "Passord"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Tilkobling mislyktes",
+      "invalid_auth": "Feil ved autentisering",
+      "too_many_requests": "For mange forespørsler",
+      "api_error": "Sky-API-et avviste forespørselen",
+      "timeout": "Tidsavbrudd ved tilkobling",
+      "unknown": "Uventet feil",
+      "already_exists": "Denne kontoen er allerede konfigurert"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/nl.json
+++ b/custom_components/landroid_cloud/translations/nl.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Landroid Cloud-opties",
         "data": {
-          "command_timeout": "Time-out voor opdracht (seconden)"
+          "email": "E-mail",
+          "password": "Wachtwoord"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Kan geen verbinding maken",
+      "invalid_auth": "Fout in authenticatie",
+      "too_many_requests": "Te veel verzoeken aan de API - Probeer het opnieuw binnen 24 uur",
+      "api_error": "De cloud-API heeft de aanvraag afgewezen",
+      "timeout": "Verbindingstime-out",
+      "unknown": "Onverwachtse fout",
+      "already_exists": "Deze gebruiker is al geconfigureerd"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/no.json
+++ b/custom_components/landroid_cloud/translations/no.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Landroid Cloud-alternativer",
         "data": {
-          "command_timeout": "Tidsavbrudd for kommando (sekunder)"
+          "email": "E-post",
+          "password": "Passord"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Tilkobling mislyktes",
+      "invalid_auth": "Feil ved autentisering",
+      "too_many_requests": "For mange forespørsler",
+      "api_error": "Sky-API-et avviste forespørselen",
+      "timeout": "Tidsavbrudd ved tilkobling",
+      "unknown": "Uventet feil",
+      "already_exists": "Denne brukerkontoen er allerede konfigurert"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/pl.json
+++ b/custom_components/landroid_cloud/translations/pl.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Opcje Landroid Cloud",
         "data": {
-          "command_timeout": "Limit czasu polecenia (sekundy)"
+          "email": "Email",
+          "password": "Hasło"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Nieudane połączenie",
+      "invalid_auth": "Błąd autoryzacji",
+      "too_many_requests": "Zbyt wiele zapytań do API - spróbuj ponownie za 24 godziny.",
+      "api_error": "Cloud API odrzuciło żądanie",
+      "timeout": "Przekroczono limit czasu połączenia",
+      "unknown": "Niespodziewany błąd",
+      "already_exists": "Ta nazwa użytkownika jest już skonfigurowana"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/ro.json
+++ b/custom_components/landroid_cloud/translations/ro.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Opțiuni Landroid Cloud",
         "data": {
-          "command_timeout": "Timp limită comandă (secunde)"
+          "email": "E-mail",
+          "password": "Parolă"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "A eșuat conectarea",
+      "invalid_auth": "Eroare la autentificare",
+      "too_many_requests": "Prea multe solicitări",
+      "api_error": "API-ul cloud a respins cererea",
+      "timeout": "Timpul de conectare a expirat",
+      "unknown": "Eroare neașteptată",
+      "already_exists": "Acest cont a fost deja configurat"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/ru.json
+++ b/custom_components/landroid_cloud/translations/ru.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Параметры Landroid Cloud",
         "data": {
-          "command_timeout": "Таймаут команды (секунды)"
+          "email": "Email",
+          "password": "Пароль"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Не удалось подключиться",
+      "invalid_auth": "Ошибка аутентификации",
+      "too_many_requests": "Слишком много запросов",
+      "api_error": "Облачный API отклонил запрос",
+      "timeout": "Истекло время ожидания подключения",
+      "unknown": "Неожиданная ошибка",
+      "already_exists": "Эта учетная запись пользователя уже настроена"
     }
   },
   "entity": {

--- a/custom_components/landroid_cloud/translations/sv.json
+++ b/custom_components/landroid_cloud/translations/sv.json
@@ -49,9 +49,19 @@
       "init": {
         "title": "Landroid Cloud-alternativ",
         "data": {
-          "command_timeout": "Timeout för kommando (sekunder)"
+          "email": "E-post",
+          "password": "Lösenord"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Misslyckades med att ansluta",
+      "invalid_auth": "Fel vid autentisering",
+      "too_many_requests": "För många API-förfrågningar. Försök igen om 24 timmar",
+      "api_error": "Moln-API:t avvisade begäran",
+      "timeout": "Tidsgräns för anslutning överskreds",
+      "unknown": "Oväntat fel",
+      "already_exists": "Det här användarkontot har redan konfigurerats"
     }
   },
   "entity": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,10 +2,17 @@
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.helpers.selector import SelectSelector
 
-from custom_components.landroid_cloud.config_flow import STEP_USER_DATA_SCHEMA
+from custom_components.landroid_cloud.config_flow import (
+    STEP_USER_DATA_SCHEMA,
+    LandroidCloudOptionsFlow,
+)
+from custom_components.landroid_cloud.const import CONF_CLOUD, CONF_COMMAND_TIMEOUT
 
 
 def test_cloud_selector_uses_translated_labels() -> None:
@@ -31,3 +38,90 @@ def test_abort_translation_covers_already_in_progress() -> None:
         assert content["config"]["abort"]["already_in_progress"], (
             f"Missing already_in_progress abort translation for {translation_file.name}"
         )
+
+
+@pytest.mark.asyncio
+async def test_options_flow_shows_account_fields_without_command_timeout() -> None:
+    """Options flow should expose account credentials, not command timeout."""
+    entry = SimpleNamespace(
+        data={
+            CONF_EMAIL: "user@example.com",
+            CONF_PASSWORD: "old-secret",
+            CONF_CLOUD: "worx",
+        },
+        options={CONF_COMMAND_TIMEOUT: 12.0},
+        entry_id="entry-1",
+        unique_id="user@example.com::worx",
+    )
+    flow = LandroidCloudOptionsFlow(entry)
+
+    result = await flow.async_step_init()
+
+    assert result["step_id"] == "init"
+    schema_keys = {key.schema for key in result["data_schema"].schema}
+    assert schema_keys == {CONF_EMAIL, CONF_PASSWORD}
+    assert CONF_COMMAND_TIMEOUT not in schema_keys
+
+
+@pytest.mark.asyncio
+async def test_options_flow_updates_account_credentials(monkeypatch) -> None:
+    """Submitting options should validate and persist new account credentials."""
+    entry = SimpleNamespace(
+        data={
+            CONF_EMAIL: "user@example.com",
+            CONF_PASSWORD: "old-secret",
+            CONF_CLOUD: "worx",
+        },
+        options={CONF_COMMAND_TIMEOUT: 12.0},
+        entry_id="entry-1",
+        unique_id="user@example.com::worx",
+    )
+    updates: list[dict[str, object]] = []
+
+    class ConfigEntries:
+        """Minimal config entries manager for options flow tests."""
+
+        def async_entries(self, domain: str):
+            assert domain == "landroid_cloud"
+            return [entry]
+
+        def async_update_entry(self, _entry, **kwargs):
+            updates.append(kwargs)
+            return True
+
+    async def validate_input(user_input):
+        assert user_input == {
+            CONF_EMAIL: "new@example.com",
+            CONF_PASSWORD: "new-secret",
+            CONF_CLOUD: "worx",
+        }
+        return {"title": "new@example.com (worx)", "device_count": 1}
+
+    monkeypatch.setattr(
+        "custom_components.landroid_cloud.config_flow._validate_input",
+        validate_input,
+    )
+
+    flow = LandroidCloudOptionsFlow(entry)
+    flow.hass = SimpleNamespace(config_entries=ConfigEntries())
+
+    result = await flow.async_step_init(
+        {
+            CONF_EMAIL: "new@example.com",
+            CONF_PASSWORD: "new-secret",
+        }
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"] == {}
+    assert updates == [
+        {
+            "data": {
+                CONF_EMAIL: "new@example.com",
+                CONF_PASSWORD: "new-secret",
+                CONF_CLOUD: "worx",
+            },
+            "title": "new@example.com (worx)",
+            "unique_id": "new@example.com::worx",
+        }
+    ]


### PR DESCRIPTION
## Description
Allow Landroid Cloud account email and password to be updated from the integration options flow. The options flow now validates the submitted credentials against the existing cloud provider, updates the config entry data/title/unique ID, and clears the old command timeout option from the settings flow.

Translations now show the account fields in options, and options errors use the same cloud/auth messages as setup.

## Test strategy
- ruff format
- ruff check
- pytest -q

## Known limitations
No physical mower validation was performed; credential changes are covered through the existing cloud validation path and unit tests.

## Required configuration changes
None. Existing entries continue to load; command timeout falls back to the integration default when no option is present.

## Semver
Proposed label: patch