### PR TITLE
Keep schedule details out of recorder history

### DIFF
--- a/custom_components/landroid_cloud/sensor.py
+++ b/custom_components/landroid_cloud/sensor.py
@@ -44,6 +44,26 @@ class LandroidSensorDescription(SensorEntityDescription):
     requires_online: bool = False
 
 
+SCHEDULE_UNRECORDED_ATTRIBUTES = frozenset(
+    {
+        "active",
+        "daily_progress",
+        "days",
+        "enabled",
+        "exclude_nights",
+        "next_schedule_start",
+        "one_time_schedule",
+        "party_mode_enabled",
+        "schedule_enabled",
+        "schedule_entries",
+        "schedule_protocol",
+        "schedule_time_extension",
+        "slots",
+        "time_extension",
+    }
+)
+
+
 def _battery_charging_attribute(device) -> dict[str, bool] | None:
     """Return Home Assistant battery charging attribute when available."""
     charging = getattr(device, "battery", {}).get("charging")
@@ -557,6 +577,8 @@ async def async_setup_entry(
 
 class LandroidSensor(LandroidBaseEntity, SensorEntity):
     """Representation of a Landroid cloud sensor."""
+
+    _unrecorded_attributes = SCHEDULE_UNRECORDED_ATTRIBUTES
 
     entity_description: LandroidSensorDescription
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,6 +12,7 @@ import custom_components.landroid_cloud.sensor as sensor_module
 from custom_components.landroid_cloud.const import ERROR_STATE_MAP, ERROR_STATE_OPTIONS
 from custom_components.landroid_cloud.sensor import (
     LandroidSensor,
+    SCHEDULE_UNRECORDED_ATTRIBUTES,
     SENSORS,
     _battery_cycle_value,
     _battery_charging_attribute,
@@ -163,6 +164,27 @@ def test_next_schedule_is_timestamp_sensor() -> None:
     )
 
     assert next_schedule.device_class is SensorDeviceClass.TIMESTAMP
+
+
+def test_schedule_attributes_are_excluded_from_recorder_history() -> None:
+    """Schedule sensors should not persist bulky attributes in recorder."""
+    assert LandroidSensor._unrecorded_attributes == SCHEDULE_UNRECORDED_ATTRIBUTES
+    assert {
+        "active",
+        "daily_progress",
+        "days",
+        "enabled",
+        "exclude_nights",
+        "next_schedule_start",
+        "one_time_schedule",
+        "party_mode_enabled",
+        "schedule_enabled",
+        "schedule_entries",
+        "schedule_protocol",
+        "schedule_time_extension",
+        "slots",
+        "time_extension",
+    } == SCHEDULE_UNRECORDED_ATTRIBUTES
 
 
 def test_schedule_attributes_expose_known_schedule_fields() -> None:


### PR DESCRIPTION
## Description
Exclude bulky Landroid schedule attributes from Home Assistant recorder history while keeping them available as live entity attributes.

This covers the next schedule sensor attributes, including slots and normalized schedule entries, and the auto schedule exclusion sensor attributes, including the weekly days structure.

Fixes #1275

## Test strategy
- ruff format custom_components/landroid_cloud/sensor.py tests/test_sensor.py
- ruff check --fix custom_components/landroid_cloud/sensor.py tests/test_sensor.py
- pytest tests/test_sensor.py

## Known limitations
No physical mower validation was performed. The change only affects Home Assistant recorder metadata for entity attributes.

## Required configuration changes
None.

## Proposed semver label
patch. I have not applied the semver label yet because repo instructions require explicit verification before setting or changing semver labels.