### PR TITLE
Fix TrackerEntity deprecation warning

### DIFF
--- a/custom_components/landroid_cloud/device_tracker.py
+++ b/custom_components/landroid_cloud/device_tracker.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback


### PR DESCRIPTION
## Description
Updates the device tracker entity import to use `TrackerEntity` from `homeassistant.components.device_tracker` directly. This removes the Home Assistant deprecation warning for the old `homeassistant.components.device_tracker.config_entry.TrackerEntity` alias.

Fixes #1278

## Test strategy
- `ruff format`
- `ruff check --fix`
- `pytest tests`

## Known limitations
No known limitations. This is an import-only compatibility fix and does not change runtime behavior.

## Required configuration changes
None.

## Semver
Proposed semver label: `patch`. Awaiting maintainer confirmation before setting or changing labels.