### PR TITLE
Bump pyworxcloud requirement to 6.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytest-asyncio==1.4.0
 pytest-cov==7.1.0
 pip>=26.1.2,<26.2
 ruff==0.15.15
-pyworxcloud==6.3.6
+pyworxcloud==6.4.0


### PR DESCRIPTION
## Description

Updates the development `requirements.txt` pin for pyworxcloud from `6.3.6` to `6.4.0` so it matches the integration manifest requirement.

## Test strategy

- `git status` checked before commit: only `requirements.txt` was modified.
- `ruff format .`
- `ruff check --fix .`
- `pytest` (`179 passed`, one Home Assistant/aiohttp deprecation warning)
- Verified PyPI metadata exposes `pyworxcloud` version `6.4.0`.

## Known limitations

No physical mower hardware validation was performed. This change only aligns the local development dependency pin with the released pyworxcloud package already required by the integration manifest.

## Required configuration changes

No user configuration changes are required.

## Semver

Semver label: `patch`.
