### PR TITLE
Expose GPS position for Vision/RTK mowers (dat.rtk.pos)

### DIFF
--- a/custom_components/landroid_cloud/entity.py
+++ b/custom_components/landroid_cloud/entity.py
@@ -98,6 +98,37 @@ class LandroidBaseEntity(CoordinatorEntity[LandroidCloudCoordinator]):
         return DeviceInfo(**info)
 
 
+def _rtk_position(device: DeviceHandler) -> tuple[float, float] | None:
+    """Return position from the RTK payload (dat.rtk.pos = [lat, lon]).
+
+    GPS-equipped Vision/RTK mowers report their fix under ``dat.rtk.pos``
+    instead of the legacy ``modules.4G.gps.coo`` schema parsed into
+    ``device.gps``. The full payload is retained on the device object, so
+    scan it (attribute name varies by pyworxcloud version) for ``rtk.pos``.
+    """
+    for attr in ("raw_dat", "raw_data", "_raw_dat", "data", "raw"):
+        raw = getattr(device, attr, None)
+        if not isinstance(raw, dict):
+            continue
+        candidates = [raw]
+        nested = raw.get("dat")
+        if isinstance(nested, dict):
+            candidates.append(nested)
+        for candidate in candidates:
+            rtk = candidate.get("rtk")
+            if not isinstance(rtk, dict):
+                continue
+            pos = rtk.get("pos")
+            if (
+                isinstance(pos, (list, tuple))
+                and len(pos) >= 2
+                and isinstance(pos[0], (int, float))
+                and isinstance(pos[1], (int, float))
+            ):
+                return float(pos[0]), float(pos[1])
+    return None
+
+
 def device_coordinates(device: DeviceHandler) -> tuple[float, float] | None:
     """Return normalized GPS coordinates when available."""
     gps = getattr(device, "gps", None)
@@ -110,7 +141,8 @@ def device_coordinates(device: DeviceHandler) -> tuple[float, float] | None:
         longitude = getattr(gps, "longitude", None)
 
     if not isinstance(latitude, int | float) or not isinstance(longitude, int | float):
-        return None
+        # Vision/RTK mowers report position under dat.rtk.pos, not device.gps.
+        return _rtk_position(device)
 
     return float(latitude), float(longitude)
 


### PR DESCRIPTION
## Problem

GPS-equipped **Vision / RTK** mowers never get a `device_tracker` (location) entity, even though they report a live position to the cloud.

## Root cause

`pyworxcloud` only parses the legacy `modules.4G.gps.coo` schema into `device.gps`. RTK models instead report their fix under **`dat.rtk.pos` = `[lat, lon]`** (provider e.g. `positec.*`). So:

- `device_coordinates()` reads `device.gps` → empty → returns `None`
- `device_supports_location()` then also finds no `4G` module (RTK units expose `HL`/`NL` modules) → returns `False`
- → the location entity is never created

## Fix

Scope is **position only** — no map/coverage, nothing else. `device_coordinates()` falls back to the RTK position pulled from the retained raw payload (`device.raw_dat` etc., attribute name guarded across pyworxcloud versions). `device_supports_location()` then returns `True` via its existing `device_coordinates(...) is not None` check, so the **existing** `device_tracker` entity starts working for RTK mowers with no other changes.

## Testing

Verified live on a **Landroid Vision Cloud400 (WR304E)**, fw `3.46.0+22`:
- raw `commandOut` payload contains `dat.rtk.pos = [56.41…, 10.88…]`, updating ~every 20s while mowing
- with the patch, `device_tracker.<mower>_location` reports `source_type: gps` with correct, moving `latitude`/`longitude`

Happy to move the parsing into `pyworxcloud` instead if you'd prefer it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)