### PR TITLE
Keep Landroid Cloud Current: Upgrade pyworxcloud to 6.4.2

### DIFF
--- a/custom_components/landroid_cloud/manifest.json
+++ b/custom_components/landroid_cloud/manifest.json
@@ -13,7 +13,7 @@
         "pyworxcloud"
     ],
     "requirements": [
-        "pyworxcloud==6.4.1"
+        "pyworxcloud==6.4.2"
     ],
     "version": "7.1.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pytest==9.0.3
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0
 pip>=26.1.2,<26.2
-pyworxcloud==6.4.1
+pyworxcloud==6.4.2
 ruff==0.15.17


### PR DESCRIPTION
## Description

Updates the pinned pyworxcloud dependency from 6.4.1 to 6.4.2 in both the Home Assistant integration manifest and the development requirements file.

## Test strategy

- `ruff format --check .` — passed
- `ruff check --fix .` — passed
- `pytest` — 178 passed, 1 failed

The failing test is `tests/test_number.py::test_time_extension_is_configuration_entity`: it expects `native_step == 10`, while the existing implementation defines `native_step=1`. This dependency-only change does not modify that behavior.

## Known limitations

The pre-existing time-extension step mismatch described above remains unresolved and is outside the scope of this dependency update.

## Configuration changes

No user configuration changes are required.

## Semver

Proposed label: `patch` (pending explicit user confirmation before applying it).