### PR TITLE
Update MQTT connectivity state on connection callbacks (#1327)

### DIFF
--- a/custom_components/landroid_cloud/coordinator.py
+++ b/custom_components/landroid_cloud/coordinator.py
@@ -50,8 +50,13 @@ class LandroidCloudCoordinator(DataUpdateCoordinator[dict[str, DeviceHandler]]):
             del api_data
             self._schedule_api_refresh()
 
+        def _on_mqtt_connection(state: bool) -> None:
+            del state
+            self._schedule_connection_update()
+
         self.cloud.set_callback(LandroidEvent.DATA_RECEIVED, _on_data_received)
         self.cloud.set_callback(LandroidEvent.API, _on_api_update)
+        self.cloud.set_callback(LandroidEvent.MQTT_CONNECTION, _on_mqtt_connection)
 
     async def async_shutdown(self) -> None:
         """Detach callbacks for push updates."""
@@ -59,6 +64,7 @@ class LandroidCloudCoordinator(DataUpdateCoordinator[dict[str, DeviceHandler]]):
         # Reset handlers to no-op before cloud disconnect to avoid stale callbacks.
         self.cloud.set_callback(LandroidEvent.DATA_RECEIVED, lambda **_: None)
         self.cloud.set_callback(LandroidEvent.API, lambda **_: None)
+        self.cloud.set_callback(LandroidEvent.MQTT_CONNECTION, lambda **_: None)
 
     async def _handle_push_update(self, device: DeviceHandler) -> None:
         """Merge push update into coordinator data in a race-safe manner."""
@@ -94,6 +100,13 @@ class LandroidCloudCoordinator(DataUpdateCoordinator[dict[str, DeviceHandler]]):
         except RuntimeError:
             _LOGGER.debug("Ignoring API refresh scheduling after loop shutdown")
 
+    def _schedule_connection_update(self) -> None:
+        """Schedule a connectivity-state refresh on Home Assistant's event loop."""
+        try:
+            self.hass.loop.call_soon_threadsafe(self._notify_connection_update)
+        except RuntimeError:
+            _LOGGER.debug("Ignoring connection update scheduling after loop shutdown")
+
     def _create_push_update_task(self, device: DeviceHandler) -> None:
         """Create task for processing a push update."""
         self.hass.async_create_task(self._handle_push_update(device))
@@ -101,6 +114,10 @@ class LandroidCloudCoordinator(DataUpdateCoordinator[dict[str, DeviceHandler]]):
     def _create_api_refresh_task(self) -> None:
         """Create task for processing an API refresh event."""
         self.hass.async_create_task(self._refresh_from_cloud())
+
+    def _notify_connection_update(self) -> None:
+        """Notify listeners of an MQTT connectivity change without refetching data."""
+        self.async_update_listeners()
 
     async def _async_update_data(self) -> dict[str, DeviceHandler]:
         """Return current cloud cache without triggering device updates."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,134 @@
+"""Tests for the Landroid Cloud data coordinator."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from pyworxcloud import LandroidEvent
+
+from custom_components.landroid_cloud.binary_sensor import (
+    BINARY_SENSORS,
+    LandroidBinarySensor,
+)
+from custom_components.landroid_cloud.coordinator import LandroidCloudCoordinator
+
+
+class _RecordingCloud:
+    """Minimal WorxCloud stand-in that records callback registrations."""
+
+    def __init__(self, mqtt_connected: bool | None = None) -> None:
+        self.callbacks: dict = {}
+        self.mqtt_connected = mqtt_connected
+
+    def set_callback(self, event, func) -> None:
+        self.callbacks[event] = func
+
+
+class _ImmediateLoop:
+    """Event loop stub that runs scheduled callbacks synchronously."""
+
+    def __init__(self) -> None:
+        self.scheduled: list = []
+
+    def call_soon_threadsafe(self, callback, *args) -> None:
+        self.scheduled.append((callback, args))
+        callback(*args)
+
+
+def _make_coordinator(cloud: _RecordingCloud) -> LandroidCloudCoordinator:
+    coordinator = object.__new__(LandroidCloudCoordinator)
+    coordinator.cloud = cloud
+    coordinator.hass = SimpleNamespace(loop=_ImmediateLoop())
+    coordinator.async_update_listeners = Mock()
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_async_setup_registers_mqtt_connection_callback() -> None:
+    """Coordinator must subscribe to MQTT connection-state changes."""
+    cloud = _RecordingCloud()
+    coordinator = _make_coordinator(cloud)
+
+    await coordinator.async_setup()
+
+    assert LandroidEvent.MQTT_CONNECTION in cloud.callbacks
+    assert LandroidEvent.DATA_RECEIVED in cloud.callbacks
+    assert LandroidEvent.API in cloud.callbacks
+
+
+@pytest.mark.asyncio
+async def test_mqtt_connection_event_notifies_listeners_without_refetch() -> None:
+    """A connection-state callback should refresh entities immediately."""
+    cloud = _RecordingCloud(mqtt_connected=False)
+    coordinator = _make_coordinator(cloud)
+    await coordinator.async_setup()
+
+    cloud.callbacks[LandroidEvent.MQTT_CONNECTION](state=False)
+
+    coordinator.async_update_listeners.assert_called_once_with()
+    # Scheduling must be thread-safe: pyworxcloud emits from the paho thread.
+    assert coordinator.hass.loop.scheduled
+
+
+@pytest.mark.asyncio
+async def test_reconnect_updates_stale_connectivity_sensor() -> None:
+    """Repro #1327: the connectivity sensor should track reconnect callbacks."""
+    cloud = _RecordingCloud(mqtt_connected=False)
+    coordinator = _make_coordinator(cloud)
+    await coordinator.async_setup()
+
+    entity = object.__new__(LandroidBinarySensor)
+    entity.entity_description = next(
+        description
+        for description in BINARY_SENSORS
+        if description.key == "mqtt_connected"
+    )
+    entity.coordinator = coordinator
+    entity._serial_number = "serial"
+
+    # Stale while MQTT is down.
+    assert entity.is_on is False
+
+    # pyworxcloud reconnects: the cloud property flips and the event fires.
+    cloud.mqtt_connected = True
+    cloud.callbacks[LandroidEvent.MQTT_CONNECTION](state=True)
+
+    coordinator.async_update_listeners.assert_called_once_with()
+    assert entity.is_on is True
+
+
+@pytest.mark.asyncio
+async def test_async_shutdown_resets_mqtt_connection_callback() -> None:
+    """Shutdown should neutralize the MQTT connection callback."""
+    cloud = _RecordingCloud()
+    coordinator = _make_coordinator(cloud)
+    await coordinator.async_setup()
+    setup_handler = cloud.callbacks[LandroidEvent.MQTT_CONNECTION]
+
+    await coordinator.async_shutdown()
+
+    handler = cloud.callbacks[LandroidEvent.MQTT_CONNECTION]
+    assert handler is not setup_handler
+    # The reset handler must be a harmless no-op that tolerates kwargs.
+    assert handler(state=True) is None
+    coordinator.async_update_listeners.assert_not_called()
+
+
+def test_schedule_connection_update_survives_loop_shutdown() -> None:
+    """Scheduling after loop shutdown should be swallowed, not raised."""
+    cloud = _RecordingCloud()
+    coordinator = object.__new__(LandroidCloudCoordinator)
+    coordinator.cloud = cloud
+    coordinator.async_update_listeners = Mock()
+
+    class _DeadLoop:
+        def call_soon_threadsafe(self, *_args) -> None:
+            raise RuntimeError("Event loop is closed")
+
+    coordinator.hass = SimpleNamespace(loop=_DeadLoop())
+
+    coordinator._schedule_connection_update()
+
+    coordinator.async_update_listeners.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #1327.

The `MQTT` connectivity binary sensor could stay stale for several minutes after an MQTT disconnect or reconnect. `LandroidCloudCoordinator.async_setup()` registered push callbacks for `LandroidEvent.DATA_RECEIVED` and `LandroidEvent.API`, but **not** for `LandroidEvent.MQTT_CONNECTION`. The `mqtt_connected` binary sensor reads `cloud.mqtt_connected` live, so it only re-rendered on the next coordinator/API refresh — lagging the real connection state (the reporter observed ~9 minutes of a stale `Disconnected` state after a successful reconnect).

## Change

- Register a `LandroidEvent.MQTT_CONNECTION` callback in the coordinator. When pyworxcloud reports a connection-state change, it schedules a thread-safe listener refresh (`async_update_listeners`) so connectivity-dependent entities re-read the reported state immediately, without triggering an extra data fetch.
- pyworxcloud emits these callbacks from the paho client thread, so scheduling goes through `hass.loop.call_soon_threadsafe`, matching the existing push/API scheduling and guarding against loop shutdown.
- The new callback is reset to a no-op on `async_shutdown()` alongside the existing handlers.

This is the integration-side gap (#1) noted in the issue. The separately noted pyworxcloud gap — `_on_paho_connect()` not emitting `MQTT_CONNECTION state=True` on an automatic reconnect — lives in `MTrab/pyworxcloud` and is out of scope for this integration change; this PR ensures the integration tracks every connection-state event pyworxcloud does emit.

## Tests

Adds `tests/test_coordinator.py`:
- `MQTT_CONNECTION` callback is registered on setup;
- firing the callback notifies listeners exactly once via a thread-safe schedule, with no data refetch;
- reconnect reproduction: the connectivity sensor flips from stale `off` to `on` once the event fires;
- shutdown resets the handler to a kwargs-tolerant no-op;
- scheduling after loop shutdown is swallowed, not raised.

All 5 tests fail on `master` and pass with this change. Full suite: 183 passed (1 pre-existing unrelated failure in `tests/test_number.py::test_time_extension_is_configuration_entity`, untouched by this PR). `ruff check`, `ruff format --check`, `black --check`, and `isort --check` all pass on the changed files.