### PR TITLE
Replace broken formatting workflow with Ruff

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -8,17 +8,17 @@ on:
 
 jobs:
   format:
-    name: Format with black and isort
+    name: Format with Ruff
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@v7.0.0
         with:
-          python-version: 3.11
+          python-version: "3.13"
       - name: Cache
         uses: actions/cache@v6.1.0
         with:
@@ -27,13 +27,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          python -m pip install --upgrade black isort
+          python -m pip install ruff==0.16.5
       - name: Pull again
         run: git pull || true
       - name: Run formatting
         run: |
-          python -m isort -v --multi-line 3 --trailing-comma -l 88 --recursive .
-          python -m black -v .
+          ruff format .
+          ruff check --fix .
       - name: Commit files
         run: |
           if [ $(git diff HEAD | wc -l) -gt 30 ]


### PR DESCRIPTION
## Summary

Replace the obsolete Black/isort formatting job with Ruff, matching the repository's current formatter and linter configuration.

The previous workflow installed unpinned isort releases and failed after isort 9 removed support for the `--recursive` argument. The updated job runs on Python 3.13, installs the repository's Ruff 0.16.5 version, and executes `ruff format .` followed by `ruff check --fix .` while preserving the existing automatic commit behavior.

## Test strategy

- Parsed `.github/workflows/format-code.yml` as YAML — passed
- `ruff 0.16.5 format --check .` — passed; 43 files already formatted
- `ruff 0.16.5 check .` — passed
- `git diff --check` — passed

## Known limitations

The workflow only triggers on pushes to `master` or by manual dispatch, so its complete GitHub Actions execution cannot run on this pull request without a manual dispatch. No integration runtime code is changed.

## Configuration changes

The formatting workflow now uses Python 3.13 and Ruff 0.16.5 instead of Python 3.11 with unpinned Black and isort.

Proposed semver label: `patch` (awaiting maintainer confirmation).
